### PR TITLE
Add gateway version info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,7 +198,7 @@ checksum = "d556ec1359574147ec0c4fc5eb525f3f23263a592b1a9c07e0a75b427de55c97"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -304,7 +304,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.98",
+ "syn 2.0.99",
  "which",
 ]
 
@@ -364,7 +364,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -405,9 +405,9 @@ checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "byte-slice-cast"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "byte-unit"
@@ -450,9 +450,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "camino"
@@ -590,7 +590,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -782,7 +782,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -806,7 +806,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -817,7 +817,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -854,7 +854,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -864,7 +864,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -884,7 +884,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
  "unicode-xid",
 ]
 
@@ -907,7 +907,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -918,9 +918,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encoding_rs"
@@ -948,7 +948,7 @@ checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1109,7 +1109,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1179,7 +1179,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "uuid",
- "vergen-git2",
+ "vergen-gitcl",
 ]
 
 [[package]]
@@ -1255,19 +1255,6 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
-name = "git2"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fda788993cc341f69012feba8bf45c0ba4f3291fcc08e214b4d5a7332d88aff"
-dependencies = [
- "bitflags",
- "libc",
- "libgit2-sys",
- "log",
- "url",
-]
 
 [[package]]
 name = "glob"
@@ -1428,9 +1415,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "httpdate"
@@ -1636,7 +1623,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1674,7 +1661,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1728,9 +1715,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jni"
@@ -1814,18 +1801,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
-name = "libgit2-sys"
-version = "0.18.0+1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1a117465e7e1597e8febea8bb0c410f1c7fb93b1e1cddf34363f8390367ffec"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "pkg-config",
-]
-
-[[package]]
 name = "libloading"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1833,18 +1808,6 @@ checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
  "windows-targets",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9b68e50e6e0b26f672573834882eb57759f6db9b3be2ea3c35c91188bb4eaa"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -2140,7 +2103,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "semver",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2180,7 +2143,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2236,22 +2199,22 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfe2e71e1471fe07709406bf725f710b02927c9c54b2b5b2ec0e8087d97c327d"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e859e6e5bd50440ab63c47e3ebabc90f26251f7c73c3d3e837b74a1cc3fa67"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2268,9 +2231,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polyval"
@@ -2307,12 +2270,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.29"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
+checksum = "f1ccf34da56fc294e7d4ccf69a85992b7dfb826b7cf57bac6a70bba3494cc08a"
 dependencies = [
  "proc-macro2",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2409,9 +2372,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
 dependencies = [
  "proc-macro2",
 ]
@@ -2441,7 +2404,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.21",
+ "zerocopy 0.8.22",
 ]
 
 [[package]]
@@ -2497,9 +2460,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b568323e98e49e2a0899dcee453dd679fae22d69adf9b11dd508d1549b7e2f"
+checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
  "bitflags",
 ]
@@ -2607,9 +2570,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.11"
+version = "0.17.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5349ae27d3887ca812fb375b45a4fbb36d8d12d2df394968cd86e35683fe73"
+checksum = "ed9b823fa29b721a59671b41d6b06e66b29e0628e207e8b1c3ceeda701ec928d"
 dependencies = [
  "cc",
  "cfg-if",
@@ -2826,21 +2789,21 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "salvo"
-version = "0.76.2"
+version = "0.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46dc13467cdac5e421cc4b8169c388c709ad08f27e7370161cd85ad17febe223"
+checksum = "fb8066ef467b29554314ef5d7c2afa3c50706318f6780ec9ad26e62e4bd0ffac"
 dependencies = [
  "salvo-compression",
  "salvo-jwt-auth",
@@ -2852,9 +2815,9 @@ dependencies = [
 
 [[package]]
 name = "salvo-compression"
-version = "0.76.2"
+version = "0.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ff1a18c4d8646463ee621cc31a358e7fdbe2f69ee3f1bba14e31adab8acbe48"
+checksum = "a7d9333b8428e9f011e86423c25f68b47dce4e708ac897c6beecc0a46c94a9ba"
 dependencies = [
  "brotli",
  "bytes",
@@ -2888,9 +2851,9 @@ dependencies = [
 
 [[package]]
 name = "salvo-jwt-auth"
-version = "0.76.2"
+version = "0.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f5def10a4dbc030fcf9aa830ae82c004923a3236f505eb9834b5bfb5cf3b90d"
+checksum = "8b448452d14e11dfbc5044a26e1d2560ea985b5cfc1add051fa1cac543fbac48"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2908,9 +2871,9 @@ dependencies = [
 
 [[package]]
 name = "salvo-proxy"
-version = "0.76.2"
+version = "0.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b3ac033974383d6cae2838b50e3ae1dc181eaea1022a10c0301339e1d0c7724"
+checksum = "5e42ccd7b2c1fd5f1003a121ed4c341d02f0922e8055247353d60e8f99807ecd"
 dependencies = [
  "fastrand",
  "futures-util",
@@ -2926,9 +2889,9 @@ dependencies = [
 
 [[package]]
 name = "salvo-rate-limiter"
-version = "0.76.2"
+version = "0.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf580c3f2f21ce7dc31c2ff73044ebefb071664ccb6a1d15a00c88f1337807d"
+checksum = "fff934e9f92a1345abeb39f23e2692d0006e6506931c4ce5c0d99a9ca934c1ca"
 dependencies = [
  "moka",
  "salvo_core",
@@ -2940,20 +2903,20 @@ dependencies = [
 
 [[package]]
 name = "salvo-serde-util"
-version = "0.76.2"
+version = "0.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3b212dd10678b447232511cc763b25b41dd4d49f1c7822dbdd50480d06f32d"
+checksum = "5ae99ade2c3b67273b73833ce835afe7f99a2f229156deadb8fcbbe84f538c08"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "salvo_core"
-version = "0.76.2"
+version = "0.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3931c89631c1aa8f2b346f58d5de6be6d69dcdd742a43afc89272afeafb849e7"
+checksum = "7daf20bc9f8657b7cbd17c2bfd29d03874a119758ef4cf01e04d3985be071873"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2998,9 +2961,9 @@ dependencies = [
 
 [[package]]
 name = "salvo_extra"
-version = "0.76.2"
+version = "0.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8a672e494584051136fe9a61771a93b30d5644e0a4ff65ac1ecde6523875f20"
+checksum = "b3819952dabd1e84c6ac82510a4928556ffe652aa8667221d4d30c34fbb97135"
 dependencies = [
  "base64 0.22.1",
  "etag",
@@ -3020,16 +2983,16 @@ dependencies = [
 
 [[package]]
 name = "salvo_macros"
-version = "0.76.2"
+version = "0.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa924c2cb7928c83704f19e082942573954307502bbda746a800fc436a66c9d9"
+checksum = "5e62df43719ce6097c80ca4ad253f7cd3aec233e280e53b8aeda6a0f49f96b37"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
  "regex",
  "salvo-serde-util",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3141,9 +3104,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 dependencies = [
  "serde",
 ]
@@ -3171,9 +3134,9 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.15"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
+checksum = "364fec0df39c49a083c9a8a18a23a6bcfd9af130fe9fe321d18520a0d113e09e"
 dependencies = [
  "serde",
 ]
@@ -3186,14 +3149,14 @@ checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.139"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -3354,9 +3317,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "e02e925281e18ffd9d640e234264753c43edc62d64b2d4cf898f1bc5e75f3fc2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3380,7 +3343,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3456,7 +3419,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3467,7 +3430,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3482,9 +3445,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "dad298b01a40a23aac4580b67e3dbedb7cc8402f3592d7f49469de2ea4aecdd8"
 dependencies = [
  "deranged",
  "itoa",
@@ -3499,15 +3462,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "765c97a5b985b7c11d7bc27fa927dc4fe6af3a6dfb021d28deb60d3bf51e76ef"
 
 [[package]]
 name = "time-macros"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "e8093bc3e81c3bc5f7879de09619d06c9a5a5e45ca44dfeeb7225bae38005c5c"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3564,7 +3527,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3697,7 +3660,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3798,9 +3761,9 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-xid"
@@ -3891,12 +3854,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "vergen"
 version = "9.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3913,14 +3870,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "vergen-git2"
+name = "vergen-gitcl"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86bae87104cb2790cdee615c2bb54729804d307191732ab27b1c5357ea6ddc5"
+checksum = "b2f89d70a58a4506a6079cedf575c64cf51649ccbb4e02a63dac539b264b7711"
 dependencies = [
  "anyhow",
  "derive_builder",
- "git2",
  "rustversion",
  "time",
  "vergen",
@@ -4000,7 +3956,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
  "wasm-bindgen-shared",
 ]
 
@@ -4035,7 +3991,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4183,7 +4139,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -4194,7 +4150,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -4395,7 +4351,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
  "synstructure",
 ]
 
@@ -4411,11 +4367,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf01143b2dd5d134f11f545cf9f1431b13b749695cb33bcce051e7568f99478"
+checksum = "09612fda0b63f7cb9e0af7e5916fe5a1f8cdcb066829f10f36883207628a4872"
 dependencies = [
- "zerocopy-derive 0.8.21",
+ "zerocopy-derive 0.8.22",
 ]
 
 [[package]]
@@ -4426,18 +4382,18 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712c8386f4f4299382c9abee219bee7084f78fb939d88b6840fcc1320d5f6da2"
+checksum = "79f81d38d7a2ed52d8f034e62c568e111df9bf8aba2f7cf19ddc5bf7bd89d520"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -4457,7 +4413,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
  "synstructure",
 ]
 
@@ -4478,7 +4434,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -4500,7 +4456,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,10 @@
 name = "gateway"
 version = "0.1.0"
 edition = "2021"
+build = "src/build.rs"
 
 [dependencies]
-salvo = { version = "0.76.2", features = ["quinn", "rustls", "rate-limiter", "affix-state", "size-limiter", "compression"] }
+salvo = { version = "0.77.0", features = ["quinn", "rustls", "rate-limiter", "affix-state", "size-limiter", "compression"] }
 tokio = { version = "1.43.0", features = ["full"] }
 async-tungstenite = { version = "0.29.1", features = ["tokio-runtime", "tokio-rustls-native-certs"] }
 futures = "0.3.31"
@@ -23,10 +24,10 @@ rustls = { version = "0.23.23" }
 toml = "0.8.20"
 uuid = { version = "1.15.1", features = ["v4", "serde"] }
 serde = { version = "1.0.218", features = ["derive"] }
-serde_json = "1.0.139"
+serde_json = "1.0.140"
 rmp-serde = "1.3.0"
 anyhow = "1.0.97"
-bytes = "1.10.0"
+bytes = "1.10.1"
 rcgen = { version = "0.13.2", features = ["pem"] }
 foldhash = "0.1.4"
 scc = "2.3.3"
@@ -39,7 +40,8 @@ bs58 = "0.5.1"
 itertools = "0.14.0"
 
 [build-dependencies]
-vergen-git2 = { version = "1.0.5", features = ["build", "cargo", "rustc"] }
+anyhow = "1.0.95"
+vergen-gitcl = { version = "1.0.5", features = ["build", "cargo", "rustc"] }
 
 [profile.release]
 codegen-units = 1

--- a/config.toml
+++ b/config.toml
@@ -17,12 +17,14 @@ receive_message_timeout_ms = 2000
 compression = true
 compression_lvl = 3
 port = 4443
-load_rate_limit = 10
+load_rate_limit = 60
 leader_rate_limit = 10
 add_task_rate_limit = 100
 request_size_limit = 1572864
 bittensor_wss = "wss://entrypoint-finney.opentensor.ai:443"
 signature_freshness_threshold = 30
+subnet_number = 17
+subnet_poll_interval_sec = 3600
 
 [cert]
 dangerous_skip_verification = true

--- a/dev-env/config/config1.toml
+++ b/dev-env/config/config1.toml
@@ -17,12 +17,14 @@ receive_message_timeout_ms = 2000
 compression = true
 compression_lvl = 3
 port = 4443
-load_rate_limit = 10
+load_rate_limit = 60
 leader_rate_limit = 10
 add_task_rate_limit = 100
 request_size_limit = 1572864
 bittensor_wss = "wss://entrypoint-finney.opentensor.ai:443"
 signature_freshness_threshold = 30
+subnet_number = 17
+subnet_poll_interval_sec = 3600
 
 [cert]
 dangerous_skip_verification = true

--- a/dev-env/config/config2.toml
+++ b/dev-env/config/config2.toml
@@ -17,12 +17,14 @@ receive_message_timeout_ms = 2000
 compression = true
 compression_lvl = 3
 port = 4443
-load_rate_limit = 10
+load_rate_limit = 60
 leader_rate_limit = 10
 add_task_rate_limit = 100
 request_size_limit = 1572864
 bittensor_wss = "wss://entrypoint-finney.opentensor.ai:443"
 signature_freshness_threshold = 30
+subnet_number = 17
+subnet_poll_interval_sec = 3600
 
 [cert]
 dangerous_skip_verification = true

--- a/dev-env/config/config3.toml
+++ b/dev-env/config/config3.toml
@@ -17,12 +17,14 @@ receive_message_timeout_ms = 2000
 compression = true
 compression_lvl = 3
 port = 4443
-load_rate_limit = 10
+load_rate_limit = 60
 leader_rate_limit = 10
 add_task_rate_limit = 100
 request_size_limit = 1572864
 bittensor_wss = "wss://entrypoint-finney.opentensor.ai:443"
 signature_freshness_threshold = 30
+subnet_number = 17
+subnet_poll_interval_sec = 3600
 
 [cert]
 dangerous_skip_verification = true

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.85"
+channel = "1.85.0"

--- a/src/api/request.rs
+++ b/src/api/request.rs
@@ -1,6 +1,8 @@
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::response::GatewayInfo;
+
 // It should be confirmed that the caller has permission to add the task before proceeding with its use.
 // The Gateway will assign a unique ID, which will be included in the response body.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -16,4 +18,29 @@ pub struct GetTasksRequest {
     pub signature: String,
     pub timestamp: String,
     pub requested_task_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayInfoExt {
+    pub node_id: u64,
+    pub domain: String,
+    pub ip: String,
+    pub name: String,
+    pub http_port: u16,
+    pub available_tasks: usize,
+    // Used to check if the request is valid
+    pub cluster_name: String,
+}
+
+impl From<GatewayInfoExt> for GatewayInfo {
+    fn from(info: GatewayInfoExt) -> Self {
+        GatewayInfo {
+            node_id: info.node_id,
+            domain: info.domain,
+            ip: info.ip,
+            name: info.name,
+            http_port: info.http_port,
+            available_tasks: info.available_tasks,
+        }
+    }
 }

--- a/src/bittensor/subnet_state.rs
+++ b/src/bittensor/subnet_state.rs
@@ -91,20 +91,23 @@ impl SubnetState {
     pub fn validate_hotkey(&self, hotkey: &str) -> Result<()> {
         let account_id = ss58_decode(hotkey)?;
 
-        let state = self.receiver.borrow();
-        let hotkey_data = state
-            .get(&account_id.0)
-            .ok_or_else(|| anyhow!("Hotkey not found in the subnet"))?;
+        let total_stake = {
+            let state = self.receiver.borrow();
+            let hotkey_data = state
+                .get(&account_id.0)
+                .ok_or_else(|| anyhow!("Hotkey not found in the subnet"))?;
+            hotkey_data.total_stake
+        };
 
         // 10000 TAO
         let required_stake: u64 = 10000 * 1_000_000_000;
 
-        if hotkey_data.total_stake > required_stake {
+        if total_stake > required_stake {
             Ok(())
         } else {
             Err(anyhow!(
                 "Hotkey found but does not have enough total stake: {} < {}",
-                hotkey_data.total_stake,
+                total_stake,
                 required_stake
             ))
         }

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,0 +1,12 @@
+use anyhow::Result;
+
+use vergen_gitcl::{BuildBuilder, CargoBuilder, Emitter, GitclBuilder, RustcBuilder};
+
+fn main() -> Result<()> {
+    Emitter::default()
+        .add_instructions(&BuildBuilder::all_build()?)?
+        .add_instructions(&CargoBuilder::all_cargo()?)?
+        .add_instructions(&GitclBuilder::all_git()?)?
+        .add_instructions(&RustcBuilder::all_rustc()?)?
+        .emit()
+}

--- a/src/common/log.rs
+++ b/src/common/log.rs
@@ -1,6 +1,3 @@
-// TODO: Remove this after the code is finalized
-#![allow(dead_code)]
-
 use tracing::info;
 use tracing::{level_filters::LevelFilter, Level};
 use tracing_appender::{

--- a/src/config.rs
+++ b/src/config.rs
@@ -73,6 +73,9 @@ pub struct HTTPConfig {
     pub request_size_limit: u64,
     pub bittensor_wss: String,
     pub signature_freshness_threshold: u64,
+    // Subnet state updater settings
+    pub subnet_number: u16,
+    pub subnet_poll_interval_sec: u64,
 }
 
 #[derive(Debug, Deserialize)]
@@ -154,6 +157,17 @@ impl FromStr for LogLevel {
             "error" => Ok(LogLevel::Error),
             _ => Err(format!("Invalid log level: {}", s)),
         }
+    }
+}
+
+fn mask_cluster_name(cluster_name: &str) -> String {
+    let char_count = cluster_name.chars().count();
+    if char_count < 3 {
+        "*".to_owned()
+    } else {
+        let visible: String = cluster_name.chars().take(3).collect();
+        let mask: String = "*".repeat(char_count - 3);
+        format!("{}{}", visible, mask)
     }
 }
 
@@ -251,7 +265,7 @@ impl fmt::Display for NodeConfig {
         writeln!(
             f,
             "    Cluster Name                 : {}",
-            self.raft.cluster_name
+            mask_cluster_name(&self.raft.cluster_name)
         )?;
         writeln!(
             f,

--- a/src/http3/error.rs
+++ b/src/http3/error.rs
@@ -5,6 +5,7 @@ use salvo::{async_trait, writing::Text, Depot, Request, Response, Writer};
 pub enum ServerError {
     BadRequest(String),
     Internal(String),
+    Unauthorized(String),
 }
 
 impl ServerError {
@@ -12,6 +13,7 @@ impl ServerError {
         match self {
             ServerError::BadRequest(_) => StatusCode::BAD_REQUEST,
             ServerError::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            ServerError::Unauthorized(_) => StatusCode::UNAUTHORIZED,
         }
     }
 }
@@ -31,6 +33,9 @@ impl Writer for ServerError {
                     message.push_str(&details);
                 }
                 res.render(Text::Plain(message));
+            }
+            ServerError::Unauthorized(msg) => {
+                res.render(Text::Plain(format!("Unauthorized request: {}", msg)));
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use common::log::{init_tracing, log_app_config, log_build_information};
 use std::{env, sync::Arc, time::Duration};
 
 use config::{read_config, NodeConfig};
-use raft::{start_gateway_single, start_gateway_vote};
+use raft::{start_gateway_bootstrap, start_gateway_single, start_gateway_vote};
 use tracing::info;
 
 mod api;
@@ -20,7 +20,11 @@ struct Cli {
     #[arg(short, long, value_name = "FILE")]
     config: Option<String>,
 
-    /// Run in single-node test mode
+    // First node will be bootstrapped as the leader.
+    #[arg(short, long)]
+    bootstrap: bool,
+
+    // Run in single-node test mode.
     #[arg(short, long)]
     test: bool,
 }
@@ -49,6 +53,8 @@ async fn main() {
     loop {
         let result = if cli.test {
             start_gateway_single(node_config.clone()).await
+        } else if cli.bootstrap {
+            start_gateway_bootstrap(node_config.clone()).await
         } else {
             start_gateway_vote(node_config.clone()).await
         };

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1,6 +1,3 @@
-// TODO: Remove this after the code is finalized
-#![allow(dead_code)]
-
 use std::convert::TryFrom;
 use std::error::Error;
 use std::fmt;
@@ -20,8 +17,6 @@ use tokio::sync::RwLock;
 use crate::raft::NodeId;
 use crate::raft::Raft;
 use crate::raft::TypeConfig;
-
-pub const MAX_MESSAGE_SIZE: usize = 64 * 1024; // 64KB default limit
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "msg_type", content = "data")]
@@ -102,7 +97,7 @@ impl TryFrom<RaftMessageType> for VoteResponse<u64> {
 
 #[derive(Debug, Clone)]
 pub struct Protocol {
-    connection: Connection,
+    _connection: Connection,
     max_message_size: usize,
     send_timeout_ms: Duration,
     receive_message_timeout_ms: Duration,
@@ -116,7 +111,7 @@ impl Protocol {
         receive_message_timeout_ms: Duration,
     ) -> Self {
         Self {
-            connection,
+            _connection: connection,
             max_message_size,
             send_timeout_ms,
             receive_message_timeout_ms,

--- a/src/raft/client/mod.rs
+++ b/src/raft/client/mod.rs
@@ -12,10 +12,9 @@ use crate::{
 
 #[derive(Debug, Clone)]
 pub struct RClient {
-    endpoint: Endpoint,
+    _endpoint: Endpoint,
     pub connection: Connection,
     protocol: Protocol,
-    max_message_size: usize,
 }
 
 impl RClient {
@@ -23,7 +22,6 @@ impl RClient {
         remote_addr: &str,
         server_name: &str,
         local_bind_addr: &str,
-        max_message_size: usize,
         dangerous_skip_verification: bool,
         protocol_cfg: ProtocolConfig,
     ) -> Result<Self> {
@@ -83,10 +81,9 @@ impl RClient {
         );
 
         Ok(Self {
-            endpoint,
+            _endpoint: endpoint,
             connection,
             protocol,
-            max_message_size,
         })
     }
 
@@ -108,7 +105,7 @@ impl RClient {
 mod tests {
     use super::*;
     use crate::config::ProtocolConfig;
-    use crate::protocol::{RaftMessageType, MAX_MESSAGE_SIZE};
+    use crate::protocol::RaftMessageType;
     use crate::raft::network::Network;
     use crate::raft::server::RServer;
     use crate::raft::{LogStore, StateMachineStore, TypeConfig};
@@ -154,15 +151,7 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(100)).await;
 
         let client_addr = "127.0.0.1:8889";
-        let client = RClient::new(
-            server_addr,
-            "localhost",
-            client_addr,
-            MAX_MESSAGE_SIZE,
-            true,
-            pcfg,
-        )
-        .await?;
+        let client = RClient::new(server_addr, "localhost", client_addr, true, pcfg).await?;
 
         assert!(client.connection.stable_id() > 0);
 
@@ -183,15 +172,8 @@ mod tests {
 
         println!("Creating client");
         let client_addr = "127.0.0.1:7778";
-        let client = RClient::new(
-            server_addr,
-            "localhost",
-            client_addr,
-            MAX_MESSAGE_SIZE,
-            true,
-            pcfg.clone(),
-        )
-        .await?;
+        let client =
+            RClient::new(server_addr, "localhost", client_addr, true, pcfg.clone()).await?;
 
         println!("Testing initial connection");
         assert!(client.connection.stable_id() > 0);
@@ -232,15 +214,8 @@ mod tests {
     #[tokio::test]
     async fn test_connection_failure() -> Result<()> {
         let pcfg = ProtocolConfig::default();
-        let result = RClient::new(
-            "127.0.0.1:9999",
-            "localhost",
-            "127.0.0.1:9998",
-            MAX_MESSAGE_SIZE,
-            true,
-            pcfg,
-        )
-        .await;
+        let result =
+            RClient::new("127.0.0.1:9999", "localhost", "127.0.0.1:9998", true, pcfg).await;
         assert!(result.is_err());
         Ok(())
     }

--- a/src/raft/server/mod.rs
+++ b/src/raft/server/mod.rs
@@ -12,9 +12,8 @@ use tracing::{debug, error, info};
 use super::Raft;
 
 pub struct RServer {
-    endpoint: Endpoint,
-    server_config: ServerConfig,
-    pub raft: Arc<RwLock<Raft>>,
+    _endpoint: Endpoint,
+    _server_config: ServerConfig,
     accept_task: JoinHandle<()>,
     cancel_token: CancellationToken,
 }
@@ -77,9 +76,8 @@ impl RServer {
         });
 
         Ok(Self {
-            endpoint,
-            server_config,
-            raft,
+            _endpoint: endpoint,
+            _server_config: server_config,
             accept_task,
             cancel_token,
         })
@@ -152,7 +150,6 @@ impl RServer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::protocol::MAX_MESSAGE_SIZE;
     use crate::raft::{network::Network, LogStore, StateMachineStore, TypeConfig};
     use anyhow::Result;
     use foldhash::quality::RandomState;
@@ -221,15 +218,8 @@ mod tests {
         // Give the server some time to start
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
-        let client = crate::raft::client::RClient::new(
-            addr,
-            "localhost",
-            "127.0.0.1:0",
-            MAX_MESSAGE_SIZE,
-            true,
-            pcfg,
-        )
-        .await?;
+        let client =
+            crate::raft::client::RClient::new(addr, "localhost", "127.0.0.1:0", true, pcfg).await?;
         assert!(client.connection.stable_id() > 0);
 
         Ok(())


### PR DESCRIPTION
This PR introduces the following changes:
1) Configuration of subnet state updater settings via a config file.
2) Addition of a /get_version endpoint to retrieve gateway information, similar to the implementation in the asset saver project.
3) Simplifications of the current code base.
4) Verify the cluster_name when making a write request to update the internal status of the node.

```
Git Branch: sn-178-version-info
Git Commit ID: 586c996824e8adcd1b746a0bb3b3b0111a46089f
Git Commit Message: Add gateway version info
Build Date: 2025-03-06
Rust Channel: stable
Rust Version: 1.85.0
Optimization Level: 3
```