### PR TITLE
Add queue length check and error handling

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -27,6 +27,7 @@ wss_max_connect_time = 10
 signature_freshness_threshold = 30
 subnet_number = 17
 subnet_poll_interval_sec = 3600
+max_task_queue_len = 10000
 
 [db]
 host = ""

--- a/dev-env/config/config1.toml
+++ b/dev-env/config/config1.toml
@@ -27,6 +27,7 @@ wss_max_connect_time = 10
 signature_freshness_threshold = 30
 subnet_number = 17
 subnet_poll_interval_sec = 3600
+max_task_queue_len = 10000
 
 [db]
 host = "db"

--- a/dev-env/config/config2.toml
+++ b/dev-env/config/config2.toml
@@ -27,6 +27,7 @@ wss_max_connect_time = 10
 signature_freshness_threshold = 30
 subnet_number = 17
 subnet_poll_interval_sec = 3600
+max_task_queue_len = 10000
 
 [db]
 host = "db"

--- a/dev-env/config/config3.toml
+++ b/dev-env/config/config3.toml
@@ -27,6 +27,7 @@ wss_max_connect_time = 10
 signature_freshness_threshold = 30
 subnet_number = 17
 subnet_poll_interval_sec = 3600
+max_task_queue_len = 10000
 
 [db]
 host = "db"

--- a/src/config.rs
+++ b/src/config.rs
@@ -77,6 +77,7 @@ pub struct HTTPConfig {
     // Subnet state updater settings
     pub subnet_number: u16,
     pub subnet_poll_interval_sec: u64,
+    pub max_task_queue_len: usize,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/http3/server.rs
+++ b/src/http3/server.rs
@@ -86,6 +86,16 @@ async fn add_task_handler(
         }
     })?;
 
+    let http_cfg = depot.obtain::<HTTPConfig>().map_err(|e| {
+        error!("Failed to obtain the HTTPConfig: {:?}", e);
+        ServerError::Internal(format!("Failed to obtain the HTTPConfig: {:?}", e))
+    })?;
+
+    if queue.len() >= http_cfg.max_task_queue_len {
+        error!("Task queue is full: {} tasks", queue.len());
+        return Err(ServerError::Internal("Task queue is full".to_string()));
+    }
+
     queue.push(task.clone());
     info!("A new task has been pushed with ID: {}", task.id);
     res.render(Json(task));


### PR DESCRIPTION
This PR limits the size of the task queue to prevent the gateway from consuming excessive amounts of memory.