### PR TITLE
Implement generic key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,9 +808,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -818,9 +818,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
  "fnv",
  "ident_case",
@@ -832,9 +832,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
@@ -1034,9 +1034,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener",
  "pin-project-lite",
@@ -2165,9 +2165,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.1"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "opaque-debug"
@@ -3418,9 +3418,9 @@ checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "socket2"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",

--- a/config.toml
+++ b/config.toml
@@ -18,6 +18,8 @@ receive_message_timeout_ms = 2000
 compression = true
 compression_lvl = 3
 port = 4443
+basic_rate_limit = 30
+write_rate_limit = 10
 load_rate_limit = 60
 leader_rate_limit = 10
 add_task_rate_limit = 100
@@ -28,7 +30,7 @@ wss_max_connect_time = 10
 signature_freshness_threshold = 30
 subnet_number = 17
 subnet_poll_interval_sec = 3600
-max_task_queue_len = 10000
+max_task_queue_len = 5000
 
 [db]
 host = ""
@@ -48,6 +50,7 @@ key_file_path = ""
 max_restart_attempts = 2
 update_gateway_info_ms = 1000
 unique_validators_per_task = 3
+admin_key = "b6c8597a-00e9-493a-b6cd-5dfc7244d46b"
 
 [log]
 path = "./logs/gateway.log"

--- a/dev-env/config/config1.toml
+++ b/dev-env/config/config1.toml
@@ -18,6 +18,8 @@ receive_message_timeout_ms = 2000
 compression = true
 compression_lvl = 3
 port = 4443
+basic_rate_limit = 30
+write_rate_limit = 10
 load_rate_limit = 60
 leader_rate_limit = 10
 add_task_rate_limit = 100
@@ -28,7 +30,8 @@ wss_max_connect_time = 10
 signature_freshness_threshold = 30
 subnet_number = 17
 subnet_poll_interval_sec = 3600
-max_task_queue_len = 10000
+max_task_queue_len = 5000
+admin_key = "b6c8597a-00e9-493a-b6cd-5dfc7244d46b"
 
 [db]
 host = "db"

--- a/dev-env/config/config2.toml
+++ b/dev-env/config/config2.toml
@@ -18,6 +18,8 @@ receive_message_timeout_ms = 2000
 compression = true
 compression_lvl = 3
 port = 4443
+basic_rate_limit = 30
+write_rate_limit = 10
 load_rate_limit = 60
 leader_rate_limit = 10
 add_task_rate_limit = 100
@@ -28,7 +30,8 @@ wss_max_connect_time = 10
 signature_freshness_threshold = 30
 subnet_number = 17
 subnet_poll_interval_sec = 3600
-max_task_queue_len = 10000
+max_task_queue_len = 5000
+admin_key = "b6c8597a-00e9-493a-b6cd-5dfc7244d46b"
 
 [db]
 host = "db"

--- a/dev-env/config/config3.toml
+++ b/dev-env/config/config3.toml
@@ -18,6 +18,8 @@ receive_message_timeout_ms = 2000
 compression = true
 compression_lvl = 3
 port = 4443
+basic_rate_limit = 30
+write_rate_limit = 10
 load_rate_limit = 60
 leader_rate_limit = 10
 add_task_rate_limit = 100
@@ -28,7 +30,8 @@ wss_max_connect_time = 10
 signature_freshness_threshold = 30
 subnet_number = 17
 subnet_poll_interval_sec = 3600
-max_task_queue_len = 10000
+max_task_queue_len = 5000
+admin_key = "b6c8597a-00e9-493a-b6cd-5dfc7244d46b"
 
 [db]
 host = "db"

--- a/dev-env/init-scripts/init-schema.sql
+++ b/dev-env/init-scripts/init-schema.sql
@@ -1,5 +1,7 @@
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
 CREATE TABLE IF NOT EXISTS users (
-  id VARCHAR(255) PRIMARY KEY,
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   email VARCHAR(255) NOT NULL UNIQUE,
   display_name VARCHAR(255),
   created_at TIMESTAMP DEFAULT NOW()
@@ -8,8 +10,8 @@ CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
 
 CREATE TABLE IF NOT EXISTS api_keys (
   id SERIAL PRIMARY KEY,
-  user_id VARCHAR(255) NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-  api_key UUID NOT NULL UNIQUE,
+  user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  api_key uuid NOT NULL UNIQUE,
   created_at TIMESTAMP DEFAULT NOW(),
   updated_at TIMESTAMP DEFAULT NOW()
 );
@@ -18,10 +20,17 @@ CREATE INDEX IF NOT EXISTS idx_api_keys_api_key ON api_keys(api_key);
 
 CREATE TABLE IF NOT EXISTS auth_providers (
   id SERIAL PRIMARY KEY,
-  user_id VARCHAR(255) NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
   provider VARCHAR(50) NOT NULL,
   provider_user_id VARCHAR(255) NOT NULL,
   created_at TIMESTAMP DEFAULT NOW(),
   UNIQUE (provider, provider_user_id)
 );
 CREATE INDEX IF NOT EXISTS idx_auth_providers_user_id ON auth_providers(user_id);
+
+INSERT INTO users (id, email, display_name)
+VALUES ('123e4567-e89b-12d3-a456-426614174000', 'user@example.com', 'Example User');
+
+INSERT INTO api_keys (user_id, api_key)
+VALUES ('123e4567-e89b-12d3-a456-426614174000', '123e4567-e89b-12d3-a456-426614174001')
+RETURNING id, user_id, api_key, created_at, updated_at;

--- a/src/api/request.rs
+++ b/src/api/request.rs
@@ -1,5 +1,6 @@
 use serde::Deserialize;
 use serde::Serialize;
+use uuid::Uuid;
 
 use super::response::GatewayInfo;
 
@@ -7,17 +8,26 @@ use super::response::GatewayInfo;
 // The Gateway will assign a unique ID, which will be included in the response body.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AddTaskRequest {
-    pub api_key: String,
     pub prompt: String,
 }
 
-// Validator hotkey must be verified
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GetTasksRequest {
     pub hotkey: String,
     pub signature: String,
     pub timestamp: String,
     pub requested_task_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateGenericKey {
+    pub admin_key: Uuid,
+    pub generic_key: Uuid,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetGenericKey {
+    pub admin_key: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/api/response.rs
+++ b/src/api/response.rs
@@ -1,5 +1,6 @@
 use serde::Deserialize;
 use serde::Serialize;
+use uuid::Uuid;
 
 use super::Task;
 
@@ -14,19 +15,24 @@ pub struct GatewayInfo {
     pub last_task_acquisition: u64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct LoadResponse {
     pub gateways: Vec<GatewayInfo>,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct GenericKeyResponse {
+    pub generic_key: Uuid,
+}
+
 // It provides a vector of tasks, as well as number of tasks available per gateway
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct GetTasksResponse {
     pub tasks: Vec<Task>,
     pub gateways: Vec<GatewayInfo>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct LeaderResponse {
     pub leader_id: u64,
     pub domain: String,

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,7 @@ use serde::Deserializer;
 use std::str::FromStr;
 use std::{fmt, path::Path};
 use tracing::Level;
+use uuid::Uuid;
 
 #[derive(Debug, Deserialize)]
 pub struct BasicConfig {
@@ -67,6 +68,8 @@ pub struct HTTPConfig {
     pub compression_lvl: u32,
     pub port: u16,
     // Per minute rate limits
+    pub basic_rate_limit: usize,
+    pub write_rate_limit: usize,
     pub load_rate_limit: usize,
     pub add_task_rate_limit: usize,
     pub leader_rate_limit: usize,
@@ -79,6 +82,7 @@ pub struct HTTPConfig {
     pub subnet_number: u16,
     pub subnet_poll_interval_sec: u64,
     pub max_task_queue_len: usize,
+    pub admin_key: Uuid,
 }
 
 #[derive(Debug, Clone, Deserialize)]


### PR DESCRIPTION
This PR implements a generic key (without rate limiting for now)
The generic key is stored within the Raft data and synchronized between cluster nodes. You can also update or retrieve it using the ADMIN API KEY.