### PR TITLE
Add external ip to config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "backon"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "970d91570c01a8a5959b36ad7dd1c30642df24b6b3068710066f6809f7033bb7"
+checksum = "fd0b50b1b78dbadd44ab18b3c794e496f3a139abb9fbc27d9c94c4eebbb96496"
 dependencies = [
  "fastrand",
  "gloo-timers",
@@ -529,9 +529,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.17"
+version = "1.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
+checksum = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c"
 dependencies = [
  "jobserver",
  "libc",
@@ -763,9 +763,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -898,9 +898,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
  "serde",
@@ -1029,9 +1029,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -1088,9 +1088,9 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "flagset"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3ea1ec5f8307826a5b71094dd91fc04d4ae75d5709b20ad351c7fb4815c86ec"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "flate2"
@@ -1265,6 +1265,7 @@ dependencies = [
  "rmp-serde",
  "rustls",
  "rustls-pemfile",
+ "rustls-platform-verifier",
  "salvo",
  "scc",
  "schnorrkel",
@@ -1794,9 +1795,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -1949,9 +1950,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -2055,9 +2056,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
 ]
@@ -2465,9 +2466,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5316f57387668042f561aae71480de936257848f9c43ce528e311d89a07cadeb"
+checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
 dependencies = [
  "proc-macro2",
  "syn 2.0.100",
@@ -2663,9 +2664,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
  "bitflags",
 ]
@@ -2901,15 +2902,15 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.9.3",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.25"
+version = "0.23.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
+checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3454,9 +3455,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "socket2"
@@ -3738,9 +3739,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4152,9 +4153,9 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vergen"
-version = "9.0.4"
+version = "9.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d2f179f8075b805a43a2a21728a46f0cc2921b3c58695b28fa8817e103cd9a"
+checksum = "6b2bf58be11fc9414104c6d3a2e464163db5ef74b12296bda593cac37b6e4777"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -4168,9 +4169,9 @@ dependencies = [
 
 [[package]]
 name = "vergen-gitcl"
-version = "1.0.5"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2f89d70a58a4506a6079cedf575c64cf51649ccbb4e02a63dac539b264b7711"
+checksum = "b9dfc1de6eb2e08a4ddf152f1b179529638bedc0ea95e6d667c014506377aefe"
 dependencies = [
  "anyhow",
  "derive_builder",
@@ -4770,9 +4771,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
+checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
 dependencies = [
  "memchr",
 ]
@@ -4821,9 +4822,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b940ebc25896e71dd073bad2dbaa2abfe97b0a391415e22ad1326d9c54e3c4"
+checksum = "a62ce76d9b56901b19a74f19431b0d8b3bc7ca4ad685a746dfd78ca8f4fc6bda"
 
 [[package]]
 name = "xxhash-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,10 +5,20 @@ edition = "2021"
 build = "src/build.rs"
 
 [dependencies]
-salvo = { version = "0.77.1", features = ["quinn", "rustls", "rate-limiter", "affix-state", "size-limiter", "compression"] }
-tokio = { version = "1.44.1", features = ["full"] }
+salvo = { version = "0.77.1", features = [
+    "quinn",
+    "rustls",
+    "rate-limiter",
+    "affix-state",
+    "size-limiter",
+    "compression",
+] }
+tokio = { version = "1.44.2", features = ["full"] }
 tokio-postgres = { version = "0.7.13", features = ["with-uuid-1"] }
-async-tungstenite = { version = "0.29.1", features = ["tokio-runtime", "tokio-rustls-native-certs"] }
+async-tungstenite = { version = "0.29.1", features = [
+    "tokio-runtime",
+    "tokio-rustls-native-certs",
+] }
 async_zip = { version = "0.0.17", features = ["deflate"] }
 futures = "0.3.31"
 futures-util = "0.3.31"
@@ -17,14 +27,15 @@ clap = "4.5.35"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
 tracing-appender = "0.2.3"
-quinn = { version = "0.11.7", features = ["rustls","runtime-tokio", "log"] }
+quinn = { version = "0.11.7", features = ["rustls", "runtime-tokio", "log"] }
 h3 = { version = "0.0.7", features = ["tracing"] }
 h3-quinn = { version = "0.0.9" }
 http = "1.3.1"
-backon = "1.4.1"
+backon = "1.5.0"
 openraft = { version = "0.9.18", features = ["storage-v2", "serde"] }
 tokio-postgres-rustls = "0.13.0"
-rustls = { version = "0.23.25" }
+rustls = { version = "0.23.26" }
+rustls-platform-verifier = "0.5.1"
 rustls-pemfile = "2.2.0"
 toml = "0.8.20"
 uuid = { version = "1.16.0", features = ["v4", "serde"] }
@@ -46,7 +57,7 @@ itertools = "0.14.0"
 
 [build-dependencies]
 anyhow = "1.0.97"
-vergen-gitcl = { version = "1.0.5", features = ["build", "cargo", "rustc"] }
+vergen-gitcl = { version = "1.0.8", features = ["build", "cargo", "rustc"] }
 
 [profile.release]
 codegen-units = 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM rust:1.85.1-alpine3.21 AS builder
+FROM rust:1.86.0-alpine3.21 AS builder
 
 RUN apk add --no-cache build-base alpine-sdk musl-dev openssl
-RUN apk add --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community --no-cache mold>=2.36
+RUN apk add --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community --no-cache mold>=2.37.1
 
 WORKDIR /app
 COPY . /app

--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,6 @@
 [network]
-ip = "0.0.0.0"
+bind_ip = "0.0.0.0"
+external_ip = "127.0.0.1"
 domain = "localhost"
 node_id = 1
 server_port = 8080

--- a/dev-env/config/config1.toml
+++ b/dev-env/config/config1.toml
@@ -1,6 +1,7 @@
 [network]
 node_id = 1
-ip = "172.25.0.2"
+bind_ip = "172.25.0.2"
+external_ip = "172.25.0.2"
 domain = "node-1"
 server_port = 9090
 name = "node-1"

--- a/dev-env/config/config2.toml
+++ b/dev-env/config/config2.toml
@@ -1,6 +1,7 @@
 [network]
 node_id = 2
-ip = "172.25.0.3"
+bind_ip = "172.25.0.3"
+external_ip = "172.25.0.3"
 domain = "node-2"
 server_port = 9090
 name = "node-2"

--- a/dev-env/config/config3.toml
+++ b/dev-env/config/config3.toml
@@ -1,6 +1,7 @@
 [network]
 node_id = 3
-ip = "172.25.0.4"
+bind_ip = "172.25.0.4"
+external_ip = "172.25.0.4"
 domain = "node-3"
 server_port = 9090
 name = "node-3"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.85.1"
+channel = "1.86.0"

--- a/src/common/crypto.rs
+++ b/src/common/crypto.rs
@@ -1,0 +1,13 @@
+use anyhow::Result;
+use rustls::crypto::CryptoProvider;
+
+pub fn init_crypto_provider() -> Result<()> {
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .or_else(|_| {
+            CryptoProvider::get_default()
+                .map(|_| ())
+                .ok_or_else(|| anyhow::anyhow!("Failed to locate any crypto provider"))
+        })?;
+    Ok(())
+}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,4 +1,6 @@
 pub mod cert;
+pub mod crypto;
 pub mod log;
 pub mod queue;
+pub mod resolve;
 pub mod task;

--- a/src/common/resolve.rs
+++ b/src/common/resolve.rs
@@ -1,0 +1,19 @@
+use anyhow::anyhow;
+use anyhow::Result;
+use futures::future::try_join_all;
+use std::net::IpAddr;
+
+// TODO: Use it to remove node_endpoints from config file
+pub async fn _resolve_dns_names_to_ips(dns_names: &[impl AsRef<str>]) -> Result<Vec<IpAddr>> {
+    let futures = dns_names.iter().map(|dns_name| async {
+        let addrs = tokio::net::lookup_host((dns_name.as_ref(), 0)).await?;
+        let ip = addrs
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow!("No IP address found for {}", dns_name.as_ref()))?
+            .ip();
+        Ok::<IpAddr, anyhow::Error>(ip)
+    });
+    let ips = try_join_all(futures).await?;
+    Ok(ips)
+}

--- a/src/common/task.rs
+++ b/src/common/task.rs
@@ -30,7 +30,7 @@ pub struct TaskManager {
 
 #[derive(Debug, Clone, Serialize)]
 pub enum TaskStatus {
-    NoResults,
+    NoResult,
     PartialResult,
     Completed,
 }
@@ -93,7 +93,7 @@ impl TaskManager {
                     TaskStatus::Completed
                 }
             }
-            _ => TaskStatus::NoResults,
+            _ => TaskStatus::NoResult,
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,7 +19,9 @@ pub struct BasicConfig {
 
 #[derive(Debug, Deserialize)]
 pub struct NetworkConfig {
-    pub ip: String,
+    pub bind_ip: String,
+    // This IP will be used in the internal state
+    pub external_ip: String,
     pub domain: String,
     pub server_port: u16,
     pub node_id: u64,
@@ -207,7 +209,8 @@ impl fmt::Display for NodeConfig {
 
         writeln!(f, "\n  [Network]")?;
         writeln!(f, "    Name            : {}", self.network.name)?;
-        writeln!(f, "    IP              : {}", self.network.ip)?;
+        writeln!(f, "    Bind to IP      : {}", self.network.bind_ip)?;
+        writeln!(f, "    External IP     : {}", self.network.external_ip)?;
         writeln!(f, "    Domain          : {}", self.network.domain)?;
         writeln!(f, "    Server Port     : {}", self.network.server_port)?;
         writeln!(f, "    Node ID         : {}", self.network.node_id)?;

--- a/src/http3/client.rs
+++ b/src/http3/client.rs
@@ -6,6 +6,7 @@ use h3_quinn;
 use http::{self, StatusCode};
 use quinn;
 use rustls;
+use rustls_platform_verifier::BuilderVerifierExt;
 use std::sync::Arc;
 use tracing::error;
 
@@ -29,8 +30,10 @@ impl Http3Client {
                 .with_custom_certificate_verifier(SkipServerVerification::new())
                 .with_no_client_auth()
         } else {
-            rustls::ClientConfig::builder()
-                .with_root_certificates(rustls::RootCertStore::empty())
+            let crypto_provider = Arc::new(rustls::crypto::aws_lc_rs::default_provider());
+            rustls::ClientConfig::builder_with_provider(crypto_provider)
+                .with_safe_default_protocol_versions()?
+                .with_platform_verifier()
                 .with_no_client_auth()
         };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use std::{env, sync::Arc, time::Duration};
 
 use config::{read_config, NodeConfig};
 use raft::{start_gateway_bootstrap, start_gateway_single, start_gateway_vote};
-use tracing::info;
+use tracing::{error, info, warn};
 
 mod api;
 mod bittensor;
@@ -68,19 +68,19 @@ async fn main() {
             }
             Err(e) => {
                 attempts += 1;
-                info!(
+                error!(
                     "Failed to start gateway: {e}, attempt {}/{}",
                     attempts, max_attempts
                 );
 
                 if attempts >= max_attempts {
-                    info!(
+                    error!(
                         "Reached maximum restart attempts ({}). Stopping.",
                         max_attempts
                     );
                     break;
                 } else {
-                    info!("Retrying...");
+                    warn!("Retrying...");
                     tokio::time::sleep(Duration::from_secs(1)).await;
                 }
             }


### PR DESCRIPTION
This PR implements the following:

1. Adds external IP to the config - This is essential for situations where a physical network interface is unavailable, such as in AWS.
2. Parses all certificates in the chain file, not just one.
3. Validates certificates using rustls-platform-verifier.