### PR TITLE
Add last_update for the internal state, logging improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,9 +567,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",

--- a/src/api/request.rs
+++ b/src/api/request.rs
@@ -56,6 +56,7 @@ pub struct GatewayInfoExt {
     // Used to check if the request is valid
     pub cluster_name: String,
     pub last_task_acquisition: u64,
+    pub last_update: u64,
 }
 
 impl From<GatewayInfoExt> for GatewayInfo {
@@ -68,6 +69,7 @@ impl From<GatewayInfoExt> for GatewayInfo {
             http_port: info.http_port,
             available_tasks: info.available_tasks,
             last_task_acquisition: info.last_task_acquisition,
+            last_update: info.last_update,
         }
     }
 }

--- a/src/api/response.rs
+++ b/src/api/response.rs
@@ -15,6 +15,7 @@ pub struct GatewayInfo {
     pub http_port: u16,
     pub available_tasks: usize,
     pub last_task_acquisition: u64,
+    pub last_update: u64,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/http3/error.rs
+++ b/src/http3/error.rs
@@ -1,8 +1,10 @@
 use bytes::Bytes;
 use futures::stream;
 use http::{header::CONTENT_TYPE, HeaderValue, StatusCode};
+use salvo::conn::SocketAddr;
 use salvo::{async_trait, Depot, Request, Response, Writer};
 use std::convert::Infallible;
+use tracing::error;
 
 #[derive(Debug)]
 pub enum ServerError {
@@ -25,7 +27,7 @@ impl ServerError {
 
 #[async_trait]
 impl Writer for ServerError {
-    async fn write(self, _req: &mut Request, _depot: &mut Depot, res: &mut Response) {
+    async fn write(self, req: &mut Request, _depot: &mut Depot, res: &mut Response) {
         res.status_code(self.status_code());
         res.headers_mut().insert(
             CONTENT_TYPE,
@@ -44,6 +46,21 @@ impl Writer for ServerError {
             ServerError::Unauthorized(msg) => format!("Unauthorized request: {}", msg),
             ServerError::NotFound(msg) => msg,
         };
+
+        let client_ip = match req.remote_addr() {
+            SocketAddr::IPv4(addr_v4) => addr_v4.ip().to_string(),
+            SocketAddr::IPv6(addr_v6) => addr_v6.ip().to_string(),
+            _ => "unknown".to_string(),
+        };
+
+        error!(
+            "Error handling request from {}: {} {} - {}",
+            client_ip,
+            req.method(),
+            req.uri().path(),
+            msg
+        );
+
         let bytes = Bytes::from(msg);
         let single = stream::once(async move { Ok::<_, Infallible>(bytes) });
         res.stream(single);

--- a/src/raft/mod.rs
+++ b/src/raft/mod.rs
@@ -171,6 +171,14 @@ impl Gateway {
                 }
             };
 
+            let last_update = match SystemTime::now().duration_since(UNIX_EPOCH) {
+                Ok(duration) => duration.as_secs(),
+                Err(e) => {
+                    error!("SystemTime before UNIX EPOCH: {:?}", e);
+                    0
+                }
+            };
+
             let info = GatewayInfo {
                 node_id: config.network.node_id,
                 domain: config.network.domain.clone(),
@@ -179,6 +187,7 @@ impl Gateway {
                 http_port: config.http.port,
                 available_tasks: task_queue.len(),
                 last_task_acquisition: last_task_acquisition.load(Ordering::Relaxed),
+                last_update,
             };
 
             if leader == config.network.node_id {
@@ -220,6 +229,7 @@ impl Gateway {
                 available_tasks: info.available_tasks,
                 cluster_name: config.raft.cluster_name.clone(),
                 last_task_acquisition: info.last_task_acquisition,
+                last_update: info.last_update,
             };
 
             let payload = match serde_json::to_vec(&info) {


### PR DESCRIPTION
1. Improve error logging to include client details (e.g., Endpoint/IPv4/IPv6).
2. Store the last_update timestamp for each gateway in the internal state.