### PR TITLE
Add cleanup for the task queue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,9 +529,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.20"
+version = "1.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
+checksum = "8691782945451c1c383942c4874dbe63814f61cb57ef773cda2972682b7bb3c0"
 dependencies = [
  "jobserver",
  "libc",
@@ -1449,9 +1449,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
 name = "headers"
@@ -1801,7 +1801,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -2557,9 +2557,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "541d0f57c6ec747a90738a52741d3221f7960e8ac2f0ff4b1a63680e033b4ab5"
+checksum = "ee4e529991f949c5e25755532370b8af5d114acae52326361d68d47af64aa842"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -2895,9 +2895,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
  "bitflags",
  "errno",
@@ -3387,9 +3387,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3553,9 +3553,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3604,7 +3604,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.2",
  "once_cell",
- "rustix 1.0.5",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
@@ -4351,18 +4351,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "0.26.9"
+version = "0.26.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180d2741b6115c3d906577e6533ad89472d48d96df00270fccb78233073d77f7"
+checksum = "c99403924bc5f23afefc319b8ac67ed0e50669f6e52a413314cccb1fdbc93ba0"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.9"
+version = "0.26.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29aad86cec885cafd03e8305fd727c418e970a521322c91688414d5b8efba16b"
+checksum = "37493cadf42a2a939ed404698ded7fb378bf301b5011f973361779a3a74f8c93"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4778,9 +4778,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb8234a863ea0e8cd7284fcdd4f145233eb00fee02bbdd9861aec44e6477bc5"
+checksum = "9e27d6ad3dac991091e4d35de9ba2d2d00647c5d0fc26c5496dee55984ae111b"
 dependencies = [
  "memchr",
 ]

--- a/config.toml
+++ b/config.toml
@@ -56,7 +56,9 @@ update_gateway_info_ms = 1000
 unique_validators_per_task = 3
 taskmanager_initial_capacity = 1024
 taskmanager_cleanup_interval = 30
-taskmanager_result_lifetime = 300
+taskmanager_result_lifetime = 2000
+taskqueue_cleanup_interval = 1
+taskqueue_task_ttl = 1800
 
 [log]
 path = "./logs/gateway.log"

--- a/dev-env/config/config1.toml
+++ b/dev-env/config/config1.toml
@@ -57,7 +57,9 @@ update_gateway_info_ms = 1000
 unique_validators_per_task = 3
 taskmanager_initial_capacity = 1024
 taskmanager_cleanup_interval = 30
-taskmanager_result_lifetime = 300
+taskmanager_result_lifetime = 2000
+taskqueue_cleanup_interval = 1
+taskqueue_task_ttl = 1800
 
 [log]
 path = "./logs/gateway.log"

--- a/dev-env/config/config2.toml
+++ b/dev-env/config/config2.toml
@@ -57,7 +57,9 @@ update_gateway_info_ms = 1000
 unique_validators_per_task = 3
 taskmanager_initial_capacity = 1024
 taskmanager_cleanup_interval = 30
-taskmanager_result_lifetime = 300
+taskmanager_result_lifetime = 2000
+taskqueue_cleanup_interval = 1
+taskqueue_task_ttl = 1800
 
 [log]
 path = "./logs/gateway.log"

--- a/dev-env/config/config3.toml
+++ b/dev-env/config/config3.toml
@@ -57,7 +57,9 @@ update_gateway_info_ms = 1000
 unique_validators_per_task = 3
 taskmanager_initial_capacity = 1024
 taskmanager_cleanup_interval = 30
-taskmanager_result_lifetime = 300
+taskmanager_result_lifetime = 2000
+taskqueue_cleanup_interval = 1
+taskqueue_task_ttl = 1800
 
 [log]
 path = "./logs/gateway.log"

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,8 @@ pub struct BasicConfig {
     pub taskmanager_initial_capacity: usize,
     pub taskmanager_cleanup_interval: u64,
     pub taskmanager_result_lifetime: u64,
+    pub taskqueue_cleanup_interval: u64,
+    pub taskqueue_task_ttl: u64,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
This PR introduces the following changes:

1. Adds a TTL for tasks and enables automatic cleanup of the task queue.
2. Replaces tokio::watch with SCC hashmap for improved concurrency management in subnet state updater.