### PR TITLE
Implement metrics

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,7 @@ on:
 env:
   SHA: ${{ github.event.pull_request.head.sha || github.sha }}
   CARGO_TERM_COLOR: always
-  RUST_VERSION: "1.84.1"
+  RUST_VERSION: "1.86.0"
 
 jobs:
   check:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,9 +261,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b756939cb2f8dc900aa6dcd505e6e2428e9cae7ff7b028c49e3946efa70878"
+checksum = "93fcc8f365936c834db5514fc45aee5b1202d677e6b40e48468aaaa8183ca8c7"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -271,9 +271,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.28.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa9b6986f250236c27e5a204062434a773a13243d2ffc2955f37bdba4c5c6a1"
+checksum = "61b1d86e7705efe1be1b569bab41d4fa1e14e220b60a160f78de2db687add079"
 dependencies = [
  "bindgen",
  "cc",
@@ -295,9 +295,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -351,9 +351,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bitvec"
@@ -484,6 +484,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytemuck"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.21"
+version = "1.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8691782945451c1c383942c4874dbe63814f61cb57ef773cda2972682b7bb3c0"
+checksum = "32db95edf998450acc7881c932f94cd9b05c87b4b2599e8bab064753da4acfd1"
 dependencies = [
  "jobserver",
  "libc",
@@ -602,9 +608,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.37"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
+checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -612,9 +618,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.37"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
+checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1075,6 +1081,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
+name = "fastbloom"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27cea6e7f512d43b098939ff4d5a5d6fe3db07971e1d05176fe26c642d33f5b8"
+dependencies = [
+ "getrandom 0.3.3",
+ "rand 0.9.1",
+ "siphasher",
+ "wide",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1253,14 +1271,15 @@ dependencies = [
  "foldhash",
  "futures",
  "futures-util",
- "h3",
- "h3-quinn",
+ "h3 0.0.8",
+ "h3-quinn 0.0.10",
  "hex",
  "http",
  "itertools 0.14.0",
  "multer",
  "openraft",
  "parity-scale-codec",
+ "prometheus",
  "quinn",
  "rcgen",
  "rmp-serde",
@@ -1270,6 +1289,7 @@ dependencies = [
  "salvo",
  "scc",
  "schnorrkel",
+ "sdd",
  "serde",
  "serde_json",
  "tokio",
@@ -1286,10 +1306,11 @@ dependencies = [
 
 [[package]]
 name = "generator"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6bd114ceda131d3b1d665eba35788690ad37f5916457286b32ab6fd3c438dd"
+checksum = "d18470a76cb7f8ff746cf1f7470914f900252ec36bbc40b569d74b1258446827"
 dependencies = [
+ "cc",
  "cfg-if",
  "libc",
  "log",
@@ -1322,9 +1343,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1380,9 +1401,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75249d144030531f8dee69fe9cea04d3edf809a017ae445e2abdff6629e86633"
+checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1409,6 +1430,20 @@ dependencies = [
  "http",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "h3"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10872b55cfb02a821b69dc7cf8dc6a71d6af25eb9a79662bec4a9d016056b3be"
+dependencies = [
+ "bytes",
+ "fastrand",
+ "futures-util",
+ "http",
+ "pin-project-lite",
+ "tokio",
  "tracing",
 ]
 
@@ -1419,7 +1454,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98c058c00e0ff53a456ad97cc0df2d0f44fbe7a2c11c9eca87c25471ca68fa1c"
 dependencies = [
  "bytes",
- "h3",
+ "h3 0.0.7",
  "pin-project-lite",
 ]
 
@@ -1431,8 +1466,22 @@ checksum = "6d482318ae94198fc8e3cbb0b7ba3099c865d744e6ec7c62039ca7b6b6c66fbf"
 dependencies = [
  "bytes",
  "futures",
- "h3",
+ "h3 0.0.7",
  "h3-datagram",
+ "quinn",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "h3-quinn"
+version = "0.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2e732c8d91a74731663ac8479ab505042fbf547b9a207213ab7fbcbfc4f8b4"
+dependencies = [
+ "bytes",
+ "futures",
+ "h3 0.0.8",
  "quinn",
  "tokio",
  "tokio-util",
@@ -1591,7 +1640,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -1626,7 +1675,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.0",
+ "windows-core",
 ]
 
 [[package]]
@@ -1640,21 +1689,22 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
 dependencies = [
  "displaydoc",
+ "potential_utf",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1664,30 +1714,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -1695,65 +1725,52 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "2549ca8c7241c82f59c80ba2a6f415d931c5b58d24fb8412caa1a1f02c49139a"
 dependencies = [
  "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "potential_utf",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
+checksum = "8197e866e47b68f8f7d95249e172903bec06004b18b2937f1095d40a0c57de04"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
+ "icu_locale_core",
  "stable_deref_trait",
  "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
 ]
 
 [[package]]
@@ -1775,9 +1792,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1877,7 +1894,7 @@ version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "libc",
 ]
 
@@ -1935,12 +1952,12 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libloading"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+checksum = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -1957,9 +1974,9 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
@@ -1989,6 +2006,12 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "maplit"
@@ -2116,9 +2139,9 @@ dependencies = [
 
 [[package]]
 name = "multimap"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 dependencies = [
  "serde",
 ]
@@ -2451,6 +2474,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2494,6 +2526,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "protobuf"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2515,9 +2582,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3bd15a6f2967aef83887dcb9fec0014580467e33720d073560cf015a5683012"
+checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -2536,12 +2603,14 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.11"
+version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbafbbdbb0f638fe3f35f3c56739f77a8a1d070cb25603226c83339b391472b"
+checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
 dependencies = [
  "bytes",
- "getrandom 0.3.2",
+ "fastbloom",
+ "getrandom 0.3.3",
+ "lru-slab",
  "rand 0.9.1",
  "ring",
  "rustc-hash 2.1.1",
@@ -2646,7 +2715,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -2664,9 +2733,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags",
 ]
@@ -2768,7 +2837,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.26.11",
  "windows-registry",
 ]
 
@@ -2908,9 +2977,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.26"
+version = "0.23.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
+checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -2945,18 +3014,19 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
  "web-time",
+ "zeroize",
 ]
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4937d110d34408e9e5ad30ba0b0ca3b6a8a390f8db3636db60144ac4fa792750"
+checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
 dependencies = [
  "core-foundation 0.10.0",
  "core-foundation-sys",
@@ -2969,7 +3039,7 @@ dependencies = [
  "rustls-webpki",
  "security-framework",
  "security-framework-sys",
- "webpki-root-certs",
+ "webpki-root-certs 0.26.11",
  "windows-sys 0.59.0",
 ]
 
@@ -2981,9 +3051,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.1"
+version = "0.103.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
+checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3002,6 +3072,15 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "salvo"
@@ -3043,9 +3122,9 @@ checksum = "1f19a88b0ea8eb8461795886272c6ff43767909341de61a823553b246a2ecae3"
 dependencies = [
  "bytes",
  "futures-util",
- "h3",
+ "h3 0.0.7",
  "h3-datagram",
- "h3-quinn",
+ "h3-quinn 0.0.9",
  "http",
  "pin-project-lite",
  "tokio",
@@ -3597,12 +3676,12 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.7",
  "windows-sys 0.59.0",
@@ -3693,9 +3772,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3739,9 +3818,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4110,12 +4189,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
 name = "utf8-width"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4139,7 +4212,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "serde",
 ]
 
@@ -4351,18 +4424,36 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "0.26.10"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c99403924bc5f23afefc319b8ac67ed0e50669f6e52a413314cccb1fdbc93ba0"
+checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
+dependencies = [
+ "webpki-root-certs 1.0.0",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01a83f7e1a9f8712695c03eabe9ed3fbca0feff0152f33f12593e5a6303cb1a4"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.10"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37493cadf42a2a939ed404698ded7fb378bf301b5011f973361779a3a74f8c93"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.0",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4388,6 +4479,16 @@ dependencies = [
  "redox_syscall",
  "wasite",
  "web-sys",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b5576b9a81633f3e8df296ce0063042a73507636cbe956c61133dd7034ab22"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]
@@ -4423,25 +4524,24 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.58.0"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+checksum = "c5ee8f3d025738cb02bad7868bbb5f8a6327501e870bf51f1b455b0a2454a419"
 dependencies = [
- "windows-core 0.58.0",
- "windows-targets 0.52.6",
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-link",
+ "windows-numerics",
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.58.0"
+name = "windows-collections"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets 0.52.6",
+ "windows-core",
 ]
 
 [[package]]
@@ -4450,22 +4550,21 @@ version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
 dependencies = [
- "windows-implement 0.60.0",
- "windows-interface 0.59.1",
+ "windows-implement",
+ "windows-interface",
  "windows-link",
- "windows-result 0.3.2",
+ "windows-result",
  "windows-strings 0.4.0",
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.58.0"
+name = "windows-future"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+checksum = "7a1d6bbefcb7b60acd19828e1bc965da6fcf18a7e39490c5f8be71e54a19ba32"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
+ "windows-core",
+ "windows-link",
 ]
 
 [[package]]
@@ -4473,17 +4572,6 @@ name = "windows-implement"
 version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4508,23 +4596,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
 name = "windows-registry"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
- "windows-result 0.3.2",
+ "windows-result",
  "windows-strings 0.3.1",
  "windows-targets 0.53.0",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4534,16 +4623,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4778,9 +4857,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.8"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e27d6ad3dac991091e4d35de9ba2d2d00647c5d0fc26c5496dee55984ae111b"
+checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
 dependencies = [
  "memchr",
 ]
@@ -4795,16 +4874,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "wyz"
@@ -4850,9 +4923,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -4862,9 +4935,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4934,10 +5007,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerovec"
-version = "0.10.4"
+name = "zerotrie"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4946,9 +5030,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ salvo = { version = "0.78.0", features = [
     "compression",
 ] }
 multer = "3.1.0"
-tokio = { version = "1.44.2", features = ["full"] }
+tokio = { version = "1.45.0", features = ["full"] }
 tokio-postgres = { version = "0.7.13", features = ["with-uuid-1"] }
 async-tungstenite = { version = "0.29.1", features = [
     "tokio-runtime",
@@ -24,21 +24,21 @@ async_zip = { version = "0.0.17", features = ["deflate"] }
 futures = "0.3.31"
 futures-util = "0.3.31"
 tokio-util = "0.7.15"
-clap = "4.5.37"
+clap = "4.5.38"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
 tracing-appender = "0.2.3"
 quinn = { version = "0.11.7", features = ["rustls", "runtime-tokio", "log"] }
-h3 = { version = "0.0.7", features = ["tracing"] }
-h3-quinn = { version = "0.0.9" }
+h3 = { version = "0.0.8", features = ["tracing"] }
+h3-quinn = { version = "0.0.10" }
 http = "1.3.1"
 backon = "1.5.0"
 openraft = { version = "0.9.18", features = ["storage-v2", "serde"] }
 tokio-postgres-rustls = "0.13.0"
-rustls = { version = "0.23.26" }
-rustls-platform-verifier = "0.5.1"
+rustls = { version = "0.23.27" }
+rustls-platform-verifier = "0.5.3"
 rustls-pemfile = "2.2.0"
-toml = "0.8.20"
+toml = "0.8.22"
 uuid = { version = "1.16.0", features = ["v4", "serde"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
@@ -48,6 +48,7 @@ bytes = "1.10.1"
 rcgen = { version = "0.13.2", features = ["pem"] }
 foldhash = "0.1.5"
 scc = "2.3.4"
+sdd = "3.0.8"
 hex = "0.4.3"
 schnorrkel = "0.11.4"
 base64 = "0.22.1"
@@ -55,6 +56,7 @@ parity-scale-codec = { version = "3.7.4", features = ["derive"] }
 blake2 = "0.10.6"
 bs58 = "0.5.1"
 itertools = "0.14.0"
+prometheus = "0.14.0"
 
 [build-dependencies]
 anyhow = "1.0.97"

--- a/config.toml
+++ b/config.toml
@@ -12,8 +12,7 @@ node_id_discovery_retries = 5
 
 [protocol]
 max_message_size = 65536
-send_timeout_ms = 300
-receive_message_timeout_ms = 2000
+receive_message_timeout_ms = 5000
 
 [http]
 compression = true

--- a/dev-env/config/config1.toml
+++ b/dev-env/config/config1.toml
@@ -12,8 +12,7 @@ node_id_discovery_retries = 5
 
 [protocol]
 max_message_size = 65536
-send_timeout_ms = 300
-receive_message_timeout_ms = 2000
+receive_message_timeout_ms = 5000
 
 [http]
 compression = true

--- a/dev-env/config/config2.toml
+++ b/dev-env/config/config2.toml
@@ -12,8 +12,7 @@ node_id_discovery_retries = 5
 
 [protocol]
 max_message_size = 65536
-send_timeout_ms = 300
-receive_message_timeout_ms = 2000
+receive_message_timeout_ms = 5000
 
 [http]
 compression = true

--- a/dev-env/config/config3.toml
+++ b/dev-env/config/config3.toml
@@ -12,8 +12,7 @@ node_id_discovery_retries = 5
 
 [protocol]
 max_message_size = 65536
-send_timeout_ms = 300
-receive_message_timeout_ms = 2000
+receive_message_timeout_ms = 5000
 
 [http]
 compression = true

--- a/src/common/queue.rs
+++ b/src/common/queue.rs
@@ -1,7 +1,6 @@
 use foldhash::fast::RandomState;
 use foldhash::HashSetExt as _;
-use scc::HashMap;
-use scc::Queue;
+use scc::{HashMap, Queue};
 use std::hash::Hash;
 use std::sync::Arc;
 use std::thread;
@@ -15,7 +14,7 @@ const EXPIREDMAP_START_CAPACITY: usize = 8;
 
 #[derive(Clone)]
 struct QueueEntry<T> {
-    item: T,
+    item: Arc<T>,
     count: usize,
     timestamp: Instant,
 }
@@ -44,13 +43,13 @@ impl DupQueueBuilder {
         self
     }
 
-    pub fn ttl(mut self, ttl: u64) -> Self {
-        self.ttl = Duration::from_secs(ttl);
+    pub fn ttl(mut self, ttl_secs: u64) -> Self {
+        self.ttl = Duration::from_secs(ttl_secs);
         self
     }
 
-    pub fn cleanup_interval(mut self, interval: u64) -> Self {
-        self.cleanup_interval = Duration::from_secs(interval);
+    pub fn cleanup_interval(mut self, interval_secs: u64) -> Self {
+        self.cleanup_interval = Duration::from_secs(interval_secs);
         self
     }
 
@@ -103,37 +102,47 @@ where
 
     pub fn push(&self, item: T) {
         let entry = QueueEntry {
-            item,
+            item: Arc::new(item),
             count: self.inner.dup,
             timestamp: Instant::now(),
         };
         self.inner.q.push(entry);
     }
 
-    pub fn pop(&self, num: usize, hotkey: &str) -> Vec<T> {
+    pub fn pop(&self, num: usize, hotkey: &str) -> Vec<(T, Option<Duration>)> {
         let mut result = Vec::with_capacity(num);
-        while result.len() < num {
-            match self.inner.q.pop_if(|entry| {
-                let key = (*entry.item.id(), hotkey.to_string());
-                !self.inner.sent.contains(&key)
-            }) {
-                Ok(Some(shared)) => {
+        let initial_len = self.inner.q.len();
+        let mut scanned = 0;
+
+        // Try up to initial_len, or until we've got num results
+        while result.len() < num && scanned < initial_len {
+            match self.inner.q.pop() {
+                Some(shared) => {
+                    scanned += 1;
                     let mut entry = (*shared).clone();
-                    let key_str = hotkey.to_string();
-                    let key = (*entry.item.id(), key_str.clone());
-                    if self.inner.sent.insert(key.clone(), ()).is_ok() {
-                        result.push(entry.item.clone());
+                    let key = (*entry.item.id(), hotkey.to_string());
+
+                    // If this hotkey hasn't seen it yet, mark & deliver
+                    if !self.inner.sent.contains(&key) {
+                        let _ = self.inner.sent.insert(key.clone(), ());
                         entry.count -= 1;
-                        if entry.count > 0 {
-                            self.inner.q.push((*entry).clone());
+                        let dur = if entry.count == 0 {
+                            Some(Instant::now() - entry.timestamp)
                         } else {
-                            self.inner.sent.remove(&key);
-                        }
+                            None
+                        };
+                        result.push(((*entry.item).clone(), dur));
+                    }
+
+                    // If there are still duplicates left, put it back on the queue
+                    if entry.count > 0 {
+                        self.inner.q.push((*entry).clone());
                     }
                 }
-                Ok(None) | Err(_) => break,
+                None => break, // queue’s empty
             }
         }
+
         result
     }
 
@@ -151,9 +160,11 @@ mod tests {
     use super::DupQueue;
     use crate::api::Task;
     use std::collections::HashSet;
-    use std::sync::Arc;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+    use std::sync::{Arc, Barrier};
     use std::thread;
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
     use uuid::Uuid;
 
     fn create_task(prompt: &str) -> Task {
@@ -165,7 +176,7 @@ mod tests {
 
     #[test]
     fn test_single_push_pop() {
-        // With dup = 3, an element may be delivered to up to 3 distinct hotkeys.
+        // With dup = 3, an element may be delivered to up to 3 distinct hotkeys. (only the final delivery returns Some(duration))
         let queue = Arc::new(
             DupQueue::<Task>::builder()
                 .dup(3)
@@ -176,13 +187,31 @@ mod tests {
         let task = create_task("Task 1");
         queue.push(task.clone());
 
-        // Hotkey "a" receives the task.
-        assert_eq!(queue.pop(3, "a"), vec![task.clone()]);
+        // Hotkey "a" receives the task. (count goes 3→2; duration should be None)
+        let res_a = queue.pop(3, "a");
+        assert_eq!(res_a.len(), 1);
+        let (item_a, dur_a) = &res_a[0];
+        assert_eq!(item_a, &task);
+        assert!(dur_a.is_none());
+
         // Subsequent calls with the same hotkey "a" yield nothing.
         assert!(queue.pop(3, "a").is_empty());
+
         // New hotkeys "b" and "c" obtain the task.
-        assert_eq!(queue.pop(3, "b"), vec![task.clone()]);
-        assert_eq!(queue.pop(3, "c"), vec![task.clone()]);
+        //  - for "b": count goes 2→1; duration None
+        //  - for "c": count goes 1→0; duration Some(_) (final delivery)
+        let res_b = queue.pop(3, "b");
+        assert_eq!(res_b.len(), 1);
+        let (item_b, dur_b) = &res_b[0];
+        assert_eq!(item_b, &task);
+        assert!(dur_b.is_none());
+
+        let res_c = queue.pop(3, "c");
+        assert_eq!(res_c.len(), 1);
+        let (item_c, dur_c) = &res_c[0];
+        assert_eq!(item_c, &task);
+        assert!(dur_c.is_some(), "expected a duration on the final delivery");
+
         // Duplication allowance exhausted; new hotkey "d" gets nothing.
         assert!(queue.pop(3, "d").is_empty());
     }
@@ -200,36 +229,116 @@ mod tests {
         let task2 = create_task("Task 2");
         queue.push(task1.clone());
         queue.push(task2.clone());
-        // Pushing a duplicate of task1 (same content and UUID).
-        // To simulate a duplicate, we push the same task instance.
         queue.push(task1.clone());
 
-        let mut res = queue.pop(2, "key1");
-        // Sorting by prompt for a deterministic comparison.
-        res.sort_by(|a, b| a.prompt.cmp(&b.prompt));
+        let res = queue.pop(2, "key1");
+        let mut res_tasks: Vec<Task> = res.iter().map(|(task, _)| task.clone()).collect();
+        res_tasks.sort_by(|a, b| a.prompt.cmp(&b.prompt));
         let mut expected = vec![task1, task2];
         expected.sort_by(|a, b| a.prompt.cmp(&b.prompt));
-        assert_eq!(res, expected);
+        assert_eq!(res_tasks, expected);
+        for (_, duration) in res {
+            assert!(duration.is_none());
+        }
     }
 
     #[test]
     fn test_pop_more_than_exists() {
-        let queue = Arc::new(
+        for &dup in &[1usize, 4usize] {
+            let queue = Arc::new(
+                DupQueue::<Task>::builder()
+                    .dup(dup)
+                    .ttl(300)
+                    .cleanup_interval(1)
+                    .build(),
+            );
+            let task1 = create_task("Task A");
+            let task2 = create_task("Task B");
+            queue.push(task1.clone());
+            queue.push(task2.clone());
+            let res = queue.pop(50, "alpha");
+            let mut res_tasks: Vec<Task> = res.iter().map(|(task, _)| task.clone()).collect();
+            res_tasks.sort_by(|a, b| a.prompt.cmp(&b.prompt));
+            let mut expected = vec![task1.clone(), task2.clone()];
+            expected.sort_by(|a, b| a.prompt.cmp(&b.prompt));
+            assert_eq!(res_tasks, expected);
+            for (_, duration) in &res {
+                if dup == 1 {
+                    assert!(duration.is_some());
+                } else {
+                    assert!(duration.is_none());
+                }
+            }
+            if dup == 1 {
+                assert!(queue.pop(3, "beta").is_empty());
+            }
+
+            let res = queue.pop(50, "alpha");
+            assert!(res.is_empty());
+        }
+    }
+
+    #[test]
+    fn heavy_contention_pop() {
+        let q = Arc::new(
             DupQueue::<Task>::builder()
-                .dup(4)
-                .ttl(300)
+                .dup(3)
+                .ttl(10)
                 .cleanup_interval(1)
                 .build(),
         );
-        let task1 = create_task("Task A");
-        let task2 = create_task("Task B");
-        queue.push(task1.clone());
-        queue.push(task2.clone());
-        let mut res = queue.pop(3, "alpha");
-        res.sort_by(|a, b| a.prompt.cmp(&b.prompt));
-        let mut expected = vec![task1, task2];
-        expected.sort_by(|a, b| a.prompt.cmp(&b.prompt));
-        assert_eq!(res, expected);
+
+        let number_of_tasks = 10_000;
+        let producers = 2;
+        let consumers = 4;
+        let barrier = Arc::new(Barrier::new(4 + producers));
+
+        for _ in 0..producers {
+            let q_producer = Arc::clone(&q);
+            let b_producer = Arc::clone(&barrier);
+            thread::spawn(move || {
+                b_producer.wait();
+                for i in 0..number_of_tasks {
+                    q_producer.push(create_task(&i.to_string()));
+                }
+            });
+        }
+
+        let counter = Arc::new(AtomicUsize::new(0));
+        let mut handles = Vec::with_capacity(4);
+        let b_consumer = Arc::clone(&barrier);
+
+        for _ in 0..consumers {
+            let q_consumer = Arc::clone(&q);
+            let b_consumer = Arc::clone(&b_consumer);
+            let counter = Arc::clone(&counter);
+            handles.push(thread::spawn(move || {
+                b_consumer.wait();
+                let mut idle_start: Option<Instant> = None;
+                loop {
+                    if counter.load(Ordering::Relaxed) == producers * number_of_tasks {
+                        break;
+                    }
+                    let got = q_consumer.pop(7, "hot");
+                    if !got.is_empty() {
+                        counter.fetch_add(got.len(), Ordering::Relaxed);
+                        idle_start = None;
+                    } else {
+                        idle_start.get_or_insert_with(Instant::now);
+                        if idle_start.unwrap().elapsed() >= Duration::from_secs(5) {
+                            break;
+                        }
+                        thread::sleep(Duration::from_millis(50));
+                    }
+                }
+            }));
+        }
+
+        for handle in handles {
+            handle.join().expect("Thread panicked");
+        }
+
+        assert_eq!(counter.load(Ordering::Relaxed), producers * number_of_tasks);
     }
 
     #[test]
@@ -246,18 +355,25 @@ mod tests {
         queue.push(task1.clone());
         queue.push(task2.clone());
         // For hotkey "key1", both tasks are delivered initially.
-        let mut res1 = queue.pop(2, "key1");
-        res1.sort_by(|a, b| a.prompt.cmp(&b.prompt));
+        let res1 = queue.pop(2, "key1");
+        let mut res1_tasks: Vec<Task> = res1.iter().map(|(task, _)| task.clone()).collect();
+        res1_tasks.sort_by(|a, b| a.prompt.cmp(&b.prompt));
         let mut expected = vec![task1.clone(), task2.clone()];
         expected.sort_by(|a, b| a.prompt.cmp(&b.prompt));
-        assert_eq!(res1, expected);
-
+        assert_eq!(res1_tasks, expected);
+        for (_, duration) in res1 {
+            assert!(duration.is_none());
+        }
         // A subsequent pop with "key1" returns nothing.
         assert!(queue.pop(2, "key1").is_empty());
         // A new hotkey "key2" can receive them again.
-        let mut res3 = queue.pop(2, "key2");
-        res3.sort_by(|a, b| a.prompt.cmp(&b.prompt));
-        assert_eq!(res3, expected);
+        let res3 = queue.pop(2, "key2");
+        let mut res3_tasks: Vec<Task> = res3.iter().map(|(task, _)| task.clone()).collect();
+        res3_tasks.sort_by(|a, b| a.prompt.cmp(&b.prompt));
+        assert_eq!(res3_tasks, expected);
+        for (_, duration) in res3 {
+            assert!(duration.is_none());
+        }
     }
 
     #[test]
@@ -277,7 +393,6 @@ mod tests {
         });
         producer.join().unwrap();
 
-        // Spawn consumer threads each using a unique hotkey.
         let mut handles = Vec::new();
         for idx in 0..3 {
             let q = Arc::clone(&queue);
@@ -285,8 +400,11 @@ mod tests {
             handles.push(thread::spawn(move || {
                 let res = q.pop(5, &hotkey);
                 // Each pop call returns distinct tasks for that hotkey.
-                let set: HashSet<_> = res.iter().map(|t| t.id.clone()).collect();
+                let set: HashSet<_> = res.iter().map(|(task, _)| task.id.clone()).collect();
                 assert_eq!(set.len(), res.len());
+                for (_, duration) in &res {
+                    assert!(duration.is_none());
+                }
                 res
             }));
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,7 +37,6 @@ pub struct NetworkConfig {
 #[derive(Debug, Deserialize, Clone)]
 pub struct ProtocolConfig {
     pub max_message_size: usize,
-    pub send_timeout_ms: u64,
     pub receive_message_timeout_ms: u64,
 }
 
@@ -45,7 +44,6 @@ impl Default for ProtocolConfig {
     fn default() -> Self {
         Self {
             max_message_size: 64 * 1024,
-            send_timeout_ms: 300,
             receive_message_timeout_ms: 2000,
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod common;
 mod config;
 mod db;
 mod http3;
+mod metrics;
 mod protocol;
 mod raft;
 

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -1,0 +1,156 @@
+use foldhash::fast::RandomState;
+use prometheus::{opts, Counter, CounterVec, Gauge, GaugeVec, Opts, Registry};
+use scc::HashMap;
+use std::sync::Arc;
+
+/// Per-validator metrics
+pub struct MetricsEntry {
+    pub completion_time_avg: Gauge,
+    pub completion_time_max: Gauge,
+    pub completed_tasks: Counter,
+    // TODO: Implement failed_tasks
+    pub _failed_tasks: Counter,
+    pub tasks_received: Counter,
+    pub best_results_total: Gauge,
+}
+
+#[derive(Clone)]
+pub struct Metrics {
+    inner: Arc<MetricsInner>,
+}
+
+struct MetricsInner {
+    alpha: f64,
+
+    _registry: Registry,
+
+    queue_time_avg: Gauge,
+    queue_time_max: Gauge,
+
+    completion_time_avg: GaugeVec,
+    completion_time_max: GaugeVec,
+    completed_tasks: CounterVec,
+    failed_tasks: CounterVec,
+    tasks_received: CounterVec,
+    best_results_total: GaugeVec,
+
+    map: HashMap<String, Arc<MetricsEntry>, RandomState>,
+}
+
+impl Metrics {
+    pub fn new(alpha: f64) -> Result<Self, prometheus::Error> {
+        let registry = Registry::new();
+
+        // Global queue‐time metrics
+        let queue_time_avg = Gauge::with_opts(opts!("queue_time_avg", "EWMA of queue time"))?;
+        let queue_time_max = Gauge::with_opts(opts!("queue_time_max", "Max seen queue time"))?;
+        registry.register(Box::new(queue_time_avg.clone()))?;
+        registry.register(Box::new(queue_time_max.clone()))?;
+
+        // Per-validator metric vectors
+        let completion_time_avg = GaugeVec::new(
+            Opts::new("completion_time_avg", "EWMA of completion time for task"),
+            &["validator"],
+        )?;
+        let completion_time_max = GaugeVec::new(
+            Opts::new("completion_time_max", "Max completion time for task"),
+            &["validator"],
+        )?;
+        let completed_tasks = CounterVec::new(
+            Opts::new("completed_tasks_total", "Total completed tasks"),
+            &["validator"],
+        )?;
+        let failed_tasks = CounterVec::new(
+            Opts::new("failed_tasks_total", "Total failed tasks"),
+            &["validator"],
+        )?;
+        let tasks_received = CounterVec::new(
+            Opts::new("tasks_received_total", "Total tasks received"),
+            &["validator"],
+        )?;
+        let best_completed_tasks = GaugeVec::new(
+            Opts::new(
+                "best_completed_tasks",
+                "How many times specific validator won",
+            ),
+            &["validator"],
+        )?;
+
+        registry.register(Box::new(completion_time_avg.clone()))?;
+        registry.register(Box::new(completion_time_max.clone()))?;
+        registry.register(Box::new(completed_tasks.clone()))?;
+        registry.register(Box::new(failed_tasks.clone()))?;
+        registry.register(Box::new(tasks_received.clone()))?;
+        registry.register(Box::new(best_completed_tasks.clone()))?;
+
+        let inner = MetricsInner {
+            alpha,
+            _registry: registry,
+            queue_time_avg,
+            queue_time_max,
+            completion_time_avg,
+            completion_time_max,
+            completed_tasks,
+            failed_tasks,
+            tasks_received,
+            best_results_total: best_completed_tasks,
+            map: HashMap::with_capacity_and_hasher(16, RandomState::default()),
+        };
+
+        Ok(Metrics {
+            inner: Arc::new(inner),
+        })
+    }
+
+    fn get_entry(&self, key: &str) -> Arc<MetricsEntry> {
+        if let Some(e) = self.inner.map.read(key, |_, v| v.clone()) {
+            e
+        } else {
+            let e = Arc::new(MetricsEntry {
+                completion_time_avg: self.inner.completion_time_avg.with_label_values(&[key]),
+                completion_time_max: self.inner.completion_time_max.with_label_values(&[key]),
+                completed_tasks: self.inner.completed_tasks.with_label_values(&[key]),
+                _failed_tasks: self.inner.failed_tasks.with_label_values(&[key]),
+                tasks_received: self.inner.tasks_received.with_label_values(&[key]),
+                best_results_total: self.inner.best_results_total.with_label_values(&[key]),
+            });
+            let _ = self.inner.map.insert(key.to_string(), e.clone());
+            e
+        }
+    }
+
+    pub fn record_queue_time(&self, v: f64) {
+        let old = self.inner.queue_time_avg.get();
+        self.inner
+            .queue_time_avg
+            .set(self.inner.alpha * v + (1.0 - self.inner.alpha) * old);
+        let m = self.inner.queue_time_max.get().max(v);
+        self.inner.queue_time_max.set(m);
+    }
+
+    pub fn record_completion_time(&self, key: &str, v: f64) {
+        let entry = self.get_entry(key);
+        let old = entry.completion_time_avg.get();
+        entry
+            .completion_time_avg
+            .set(self.inner.alpha * v + (1.0 - self.inner.alpha) * old);
+        let m = entry.completion_time_max.get().max(v);
+        entry.completion_time_max.set(m);
+    }
+
+    pub fn inc_tasks_received(&self, key: &str) {
+        self.get_entry(key).tasks_received.inc();
+    }
+
+    pub fn inc_task_completed(&self, key: &str) {
+        self.get_entry(key).completed_tasks.inc();
+    }
+
+    pub fn _inc_task_failed(&self, key: &str) {
+        self.get_entry(key)._failed_tasks.inc();
+    }
+
+    pub fn inc_best_task(&self, key: &str) {
+        self.get_entry(key).best_results_total.inc();
+    }
+}

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -99,7 +99,6 @@ impl TryFrom<RaftMessageType> for VoteResponse<u64> {
 pub struct Protocol {
     _connection: Connection,
     max_message_size: usize,
-    send_timeout_ms: Duration,
     receive_message_timeout_ms: Duration,
 }
 
@@ -107,13 +106,11 @@ impl Protocol {
     pub fn new(
         connection: Connection,
         max_message_size: usize,
-        send_timeout_ms: Duration,
         receive_message_timeout_ms: Duration,
     ) -> Self {
         Self {
             _connection: connection,
             max_message_size,
-            send_timeout_ms,
             receive_message_timeout_ms,
         }
     }
@@ -132,8 +129,8 @@ impl Protocol {
         send.write_all(&serialized).await?;
         send.flush().await?;
         send.finish()?;
+        let _ = send.stopped().await;
 
-        let _ = tokio::time::timeout(self.send_timeout_ms, send.stopped()).await;
         Ok(())
     }
 

--- a/src/raft/client/mod.rs
+++ b/src/raft/client/mod.rs
@@ -1,7 +1,11 @@
 use anyhow::Result;
 use quinn::{Connection, Endpoint};
 use rustls_platform_verifier::BuilderVerifierExt;
-use std::{sync::Arc, time::Duration};
+use sdd::{AtomicOwned, Guard, Owned, Tag};
+use std::net::SocketAddr;
+use std::sync::atomic::Ordering::{AcqRel, Acquire};
+use std::sync::Arc;
+use std::time::Duration;
 use tracing::info;
 
 use crate::{
@@ -12,9 +16,11 @@ use crate::{
 
 #[derive(Debug, Clone)]
 pub struct RClient {
-    _endpoint: Endpoint,
-    pub connection: Connection,
-    protocol: Protocol,
+    endpoint: Arc<Endpoint>,
+    connection: Arc<AtomicOwned<Connection>>,
+    server_name: String,
+    remote_addr: SocketAddr,
+    protocol_cfg: ProtocolConfig,
 }
 
 impl RClient {
@@ -25,8 +31,8 @@ impl RClient {
         dangerous_skip_verification: bool,
         protocol_cfg: ProtocolConfig,
     ) -> Result<Self> {
-        let remote_addr: std::net::SocketAddr = remote_addr.parse()?;
-        let local_bind_addr: std::net::SocketAddr = local_bind_addr.parse()?;
+        let remote_addr: SocketAddr = remote_addr.parse()?;
+        let local_bind_addr: SocketAddr = local_bind_addr.parse()?;
 
         let mut crypto = if dangerous_skip_verification {
             rustls::ClientConfig::builder()
@@ -34,66 +40,109 @@ impl RClient {
                 .with_custom_certificate_verifier(SkipServerVerification::new())
                 .with_no_client_auth()
         } else {
-            let crypto_provider = Arc::new(rustls::crypto::aws_lc_rs::default_provider());
-            rustls::ClientConfig::builder_with_provider(crypto_provider)
+            let provider = Arc::new(rustls::crypto::aws_lc_rs::default_provider());
+            rustls::ClientConfig::builder_with_provider(provider)
                 .with_safe_default_protocol_versions()?
                 .with_platform_verifier()
                 .with_no_client_auth()
         };
-
         crypto.alpn_protocols = vec![b"h3".to_vec()];
 
-        let mut client_config = quinn::ClientConfig::new(Arc::new(
+        let mut client_cfg = quinn::ClientConfig::new(Arc::new(
             quinn::crypto::rustls::QuicClientConfig::try_from(crypto)?,
         ));
-
-        let timeout = quinn::IdleTimeout::try_from(std::time::Duration::from_secs(10))?;
-        client_config.transport_config(Arc::new({
-            let mut transport_config = quinn::TransportConfig::default();
-            transport_config.keep_alive_interval(Some(std::time::Duration::from_millis(100)));
-            transport_config.max_idle_timeout(Some(timeout));
-            transport_config
+        let timeout = quinn::IdleTimeout::try_from(Duration::from_secs(10))?;
+        client_cfg.transport_config(Arc::new({
+            let mut tx = quinn::TransportConfig::default();
+            tx.keep_alive_interval(Some(Duration::from_millis(100)));
+            tx.max_idle_timeout(Some(timeout));
+            tx
         }));
 
         let mut endpoint = Endpoint::client(local_bind_addr)?;
-        endpoint.set_default_client_config(client_config);
+        endpoint.set_default_client_config(client_cfg);
 
-        let connect = endpoint.connect(remote_addr, server_name)?;
-        let connection = connect.await?;
-
+        let conn = endpoint.connect(remote_addr, server_name)?.await?;
         info!(
-            "Successfully established connection with id: {}",
-            connection.stable_id()
-        );
-
-        let send_timeout = Duration::from_millis(protocol_cfg.send_timeout_ms);
-        let receive_timeout = Duration::from_millis(protocol_cfg.receive_message_timeout_ms);
-
-        let protocol = Protocol::new(
-            connection.clone(),
-            protocol_cfg.max_message_size,
-            send_timeout,
-            receive_timeout,
+            "Successfully established connection to {} with id: {}",
+            remote_addr,
+            conn.stable_id(),
         );
 
         Ok(Self {
-            _endpoint: endpoint,
-            connection,
-            protocol,
+            endpoint: Arc::new(endpoint),
+            connection: Arc::new(AtomicOwned::new(conn)),
+            server_name: server_name.to_string(),
+            remote_addr,
+            protocol_cfg,
         })
+    }
+
+    #[allow(dead_code)]
+    pub fn stable_id(&self) -> usize {
+        let guard = Guard::new();
+        self.connection
+            .load(Acquire, &guard)
+            .as_ref()
+            .map(|c| c.stable_id())
+            .unwrap_or(0)
+    }
+
+    async fn get_connection(&self) -> Result<Connection> {
+        let maybe_conn = {
+            let guard = Guard::new();
+            self.connection
+                .load(Acquire, &guard)
+                .as_ref()
+                .map(|c| c.clone())
+        };
+        if let Some(conn) = maybe_conn {
+            Ok(conn)
+        } else {
+            self.reconnect().await
+        }
+    }
+
+    async fn reconnect(&self) -> Result<Connection> {
+        let new_conn = self
+            .endpoint
+            .connect(self.remote_addr, &self.server_name)?
+            .await?;
+        info!(
+            "Successfully reconnected to {} with id: {}",
+            self.remote_addr,
+            new_conn.stable_id(),
+        );
+        let _ = self
+            .connection
+            .swap((Some(Owned::new(new_conn.clone())), Tag::None), AcqRel);
+        Ok(new_conn)
     }
 
     pub async fn send<T>(&self, data: T) -> Result<RaftMessageType>
     where
         T: Into<RaftMessageType>,
     {
-        let (send_stream, recv_stream) = self.connection.open_bi().await?;
+        let mut conn = self.get_connection().await?;
 
-        let message: RaftMessageType = data.into();
-        self.protocol.send_message(send_stream, message).await?;
-        let response = self.protocol.receive_message(recv_stream).await?;
+        // Try opening the stream once, on error, reconnect and open it again
+        let (send_stream, recv_stream) = match conn.open_bi().await {
+            Ok(streams) => streams,
+            Err(_) => {
+                conn = self.reconnect().await?;
+                conn.open_bi().await?
+            }
+        };
 
-        Ok(response)
+        let proto = Protocol::new(
+            conn.clone(),
+            self.protocol_cfg.max_message_size,
+            Duration::from_millis(self.protocol_cfg.receive_message_timeout_ms),
+        );
+        let msg: RaftMessageType = data.into();
+        proto.send_message(send_stream, msg).await?;
+        let resp = proto.receive_message(recv_stream).await?;
+        Ok(resp)
     }
 }
 
@@ -154,7 +203,7 @@ mod tests {
         let client_addr = "127.0.0.1:8889";
         let client = RClient::new(server_addr, "localhost", client_addr, true, pcfg).await?;
 
-        assert!(client.connection.stable_id() > 0);
+        assert!(client.stable_id() > 0);
 
         Ok(())
     }
@@ -179,7 +228,7 @@ mod tests {
             RClient::new(server_addr, "localhost", client_addr, true, pcfg.clone()).await?;
 
         println!("Testing initial connection");
-        assert!(client.connection.stable_id() > 0);
+        assert!(client.stable_id() > 0);
 
         let append_entries = RaftMessageType::AppendEntriesRequest(AppendEntriesRequest {
             vote: Vote {
@@ -222,6 +271,78 @@ mod tests {
         let result =
             RClient::new("127.0.0.1:9999", "localhost", "127.0.0.1:9998", true, pcfg).await;
         assert!(result.is_err());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_reconnect() -> Result<()> {
+        init_crypto_provider().unwrap();
+
+        let raft = create_test_raft_node(1).await?;
+        let pcfg = ProtocolConfig::default();
+        let server_addr = "127.0.0.1:6666";
+        let _server = RServer::new(server_addr, None, raft, pcfg.clone()).await?;
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let client_addr = "127.0.0.1:0";
+        let client =
+            RClient::new(server_addr, "localhost", client_addr, true, pcfg.clone()).await?;
+
+        // Helper to build a fresh AppendEntries request each time
+        fn make_append_entries() -> RaftMessageType {
+            RaftMessageType::AppendEntriesRequest(AppendEntriesRequest {
+                vote: Vote {
+                    leader_id: LeaderId {
+                        term: 1,
+                        node_id: 1,
+                    },
+                    committed: true,
+                },
+                prev_log_id: None,
+                entries: Vec::new(),
+                leader_commit: None,
+            })
+        }
+
+        // Verify initial connection
+        let response = client.send(make_append_entries()).await?;
+        assert!(matches!(
+            response,
+            RaftMessageType::AppendEntriesResponse(_)
+        ));
+
+        let initial_stable_id = client.stable_id();
+        assert!(initial_stable_id > 0);
+
+        // Close connection to force a reconnect
+        {
+            let guard = Guard::new();
+            if let Some(conn) = client.connection.load(Acquire, &guard).as_ref() {
+                conn.close(0u32.into(), b"test close");
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Send again — should reconnect under the hood
+        let response = client.send(make_append_entries()).await?;
+        assert!(matches!(
+            response,
+            RaftMessageType::AppendEntriesResponse(_)
+        ));
+
+        // Ensure we got a new connection
+        let new_stable_id = client.stable_id();
+        assert!(new_stable_id > 0);
+        assert_ne!(initial_stable_id, new_stable_id);
+
+        // Final sanity check on the new connection
+        let response = client.send(make_append_entries()).await?;
+        assert!(matches!(
+            response,
+            RaftMessageType::AppendEntriesResponse(_)
+        ));
+
         Ok(())
     }
 }

--- a/src/raft/server/mod.rs
+++ b/src/raft/server/mod.rs
@@ -107,7 +107,6 @@ impl RServer {
                     let protocol = Protocol::new(
                         connection.clone(),
                         protocol_cfg.max_message_size,
-                        Duration::from_millis(protocol_cfg.send_timeout_ms),
                         Duration::from_millis(protocol_cfg.receive_message_timeout_ms),
                     );
                     if let Err(e) = Self::handle_request(protocol, send, recv, raft.clone()).await {
@@ -229,7 +228,7 @@ mod tests {
 
         let client =
             crate::raft::client::RClient::new(addr, "localhost", "127.0.0.1:0", true, pcfg).await?;
-        assert!(client.connection.stable_id() > 0);
+        assert!(client.stable_id() > 0);
 
         Ok(())
     }


### PR DESCRIPTION
This PR implements the following changes:

1. Upgrade CI to Rust 1.86.
2. Update dependencies.
3. Add timeout option to HTTP3 POST/GET.
4. Remove send_timeout_ms only quinn stopped() used instead.
5. Redesign DupQueue to record time, add more tests.
6. Implement basic metrics.
7. Implement RClient reconnect logic and the test.
8. Expand logging in Salvo handlers.