### PR TITLE
Handle failed task in add_result

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,9 +735,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1951,9 +1951,9 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libloading"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
  "windows-targets 0.53.0",
@@ -2088,13 +2088,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3033,7 +3033,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
 dependencies = [
- "core-foundation 0.10.0",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
@@ -3359,7 +3359,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
  "bitflags",
- "core-foundation 0.10.0",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3545,9 +3545,9 @@ checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -3823,9 +3823,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.45.0"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ salvo = { version = "0.78.0", features = [
     "compression",
 ] }
 multer = "3.1.0"
-tokio = { version = "1.45.0", features = ["full"] }
+tokio = { version = "1.45.1", features = ["full"] }
 tokio-postgres = { version = "0.7.13", features = ["with-uuid-1"] }
 async-tungstenite = { version = "0.29.1", features = [
     "tokio-runtime",
@@ -28,7 +28,7 @@ clap = "4.5.38"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
 tracing-appender = "0.2.3"
-quinn = { version = "0.11.7", features = ["rustls", "runtime-tokio", "log"] }
+quinn = { version = "0.11.8", features = ["rustls", "runtime-tokio", "log"] }
 h3 = { version = "0.0.8", features = ["tracing"] }
 h3-quinn = { version = "0.0.10" }
 http = "1.3.1"
@@ -39,7 +39,7 @@ rustls = { version = "0.23.27" }
 rustls-platform-verifier = "0.5.3"
 rustls-pemfile = "2.2.0"
 toml = "0.8.22"
-uuid = { version = "1.16.0", features = ["v4", "serde"] }
+uuid = { version = "1.17.0", features = ["v4", "serde"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 rmp-serde = "1.3.0"
@@ -59,7 +59,7 @@ itertools = "0.14.0"
 prometheus = "0.14.0"
 
 [build-dependencies]
-anyhow = "1.0.97"
+anyhow = "1.0.98"
 vergen-gitcl = { version = "1.0.8", features = ["build", "cargo", "rustc"] }
 
 [profile.release]

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -8,8 +8,7 @@ pub struct MetricsEntry {
     pub completion_time_avg: Gauge,
     pub completion_time_max: Gauge,
     pub completed_tasks: Counter,
-    // TODO: Implement failed_tasks
-    pub _failed_tasks: Counter,
+    pub failed_tasks: Counter,
     pub tasks_received: Counter,
     pub best_results_total: Gauge,
 }
@@ -114,7 +113,7 @@ impl Metrics {
                 completion_time_avg: self.inner.completion_time_avg.with_label_values(&[key]),
                 completion_time_max: self.inner.completion_time_max.with_label_values(&[key]),
                 completed_tasks: self.inner.completed_tasks.with_label_values(&[key]),
-                _failed_tasks: self.inner.failed_tasks.with_label_values(&[key]),
+                failed_tasks: self.inner.failed_tasks.with_label_values(&[key]),
                 tasks_received: self.inner.tasks_received.with_label_values(&[key]),
                 best_results_total: self.inner.best_results_total.with_label_values(&[key]),
             });
@@ -150,8 +149,8 @@ impl Metrics {
         self.get_entry(key).completed_tasks.inc();
     }
 
-    pub fn _inc_task_failed(&self, key: &str) {
-        self.get_entry(key)._failed_tasks.inc();
+    pub fn inc_task_failed(&self, key: &str) {
+        self.get_entry(key).failed_tasks.inc();
     }
 
     pub fn inc_best_task(&self, key: &str) {


### PR DESCRIPTION
This PR implements the following:

1. Adds support for handling failed tasks in add_result.
2. Updates the metrics to increment the failed_tasks counter.