### PR TITLE
Feat/rate limit violation tracking claude opus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3005,6 +3005,8 @@ dependencies = [
  "chrono",
  "fallible-iterator",
  "postgres-protocol",
+ "serde_core",
+ "serde_json",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ tokio = { version = "1.49.0", features = [
 tokio-postgres = { version = "0.7.16", features = [
     "with-uuid-1",
     "with-chrono-0_4",
+    "with-serde_json-1",
 ] }
 async_zip = { version = "0.0.18", features = ["deflate"] }
 futures = "0.3.32"

--- a/dev-env/config/config-single.toml
+++ b/dev-env/config/config-single.toml
@@ -78,6 +78,7 @@ keys_cache_max_capacity = 32000
 deleted_keys_ttl_minutes = 60
 events_flush_interval_sec = 5
 events_copy_batch_size = 1000
+violation_flush_interval_sec = 60
 
 [cert]
 dangerous_skip_verification = true

--- a/dev-env/config/config1.toml
+++ b/dev-env/config/config1.toml
@@ -78,6 +78,7 @@ keys_cache_max_capacity = 32000
 deleted_keys_ttl_minutes = 60
 events_flush_interval_sec = 5
 events_copy_batch_size = 1000
+violation_flush_interval_sec = 60
 
 [cert]
 dangerous_skip_verification = true

--- a/dev-env/config/config2.toml
+++ b/dev-env/config/config2.toml
@@ -78,6 +78,7 @@ keys_cache_max_capacity = 32000
 deleted_keys_ttl_minutes = 60
 events_flush_interval_sec = 5
 events_copy_batch_size = 1000
+violation_flush_interval_sec = 60
 
 [cert]
 dangerous_skip_verification = true

--- a/dev-env/config/config3.toml
+++ b/dev-env/config/config3.toml
@@ -78,6 +78,7 @@ keys_cache_max_capacity = 32000
 deleted_keys_ttl_minutes = 60
 events_flush_interval_sec = 5
 events_copy_batch_size = 1000
+violation_flush_interval_sec = 60
 
 [cert]
 dangerous_skip_verification = true

--- a/dev-env/init-scripts/init-schema.sql
+++ b/dev-env/init-scripts/init-schema.sql
@@ -160,3 +160,15 @@ CREATE INDEX IF NOT EXISTS idx_worker_events_worker_year ON worker_events(worker
 CREATE INDEX IF NOT EXISTS idx_worker_events_worker_action_week ON worker_events(worker_id, action, bucket_week);
 CREATE INDEX IF NOT EXISTS idx_worker_events_worker_action_month ON worker_events(worker_id, action, bucket_month);
 CREATE INDEX IF NOT EXISTS idx_worker_events_worker_action_year ON worker_events(worker_id, action, bucket_year);
+
+-- Batched rate-limit violation snapshots.
+-- Each row is one periodic flush from a single gateway instance.
+-- `details` is a JSONB object mapping "client_identifier:limiter_name" -> count.
+CREATE TABLE IF NOT EXISTS rate_limit_violations (
+  id BIGSERIAL PRIMARY KEY,
+  gateway_name VARCHAR(255) NOT NULL,
+  total_count BIGINT NOT NULL,
+  details JSONB NOT NULL DEFAULT '{}',
+  created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT (NOW() AT TIME ZONE 'UTC')
+);
+CREATE INDEX IF NOT EXISTS idx_rlv_gateway_created ON rate_limit_violations(gateway_name, created_at DESC);

--- a/src/config.rs
+++ b/src/config.rs
@@ -192,6 +192,8 @@ pub struct DbConfig {
     pub events_copy_batch_size: usize,
     #[serde(default = "default_events_queue_capacity")]
     pub events_queue_capacity: usize,
+    #[serde(default = "default_violation_flush_interval_sec")]
+    pub violation_flush_interval_sec: u64,
 }
 
 fn default_deleted_keys_ttl_minutes() -> u64 {
@@ -208,6 +210,10 @@ fn default_events_copy_batch_size() -> usize {
 
 fn default_events_queue_capacity() -> usize {
     50_000
+}
+
+fn default_violation_flush_interval_sec() -> u64 {
+    60
 }
 
 fn default_max_concurrent_image_uploads() -> usize {

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -2,6 +2,7 @@ mod connection;
 mod event_recorder;
 mod key_validator;
 mod repository;
+pub mod violation_tracker;
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -17,6 +18,7 @@ use tokio_postgres::{Client, Statement};
 pub use connection::PostgresConnectionConfigOwned;
 pub use event_recorder::EventRecorder;
 pub use key_validator::{ApiKeyLookup, ApiKeyValidator};
+pub use violation_tracker::RateLimitViolationTracker;
 
 use connection::{AbortOnDropJoinHandle, StmtKey};
 
@@ -147,5 +149,106 @@ impl EventSink for Database {
 
     async fn record_worker_events_batch(&self, rows: &[WorkerEventRow]) -> Result<()> {
         Database::record_worker_events_batch(self, rows).await
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Rate-limit violation sink
+// ---------------------------------------------------------------------------
+
+/// Persists batched rate-limit violation snapshots.
+#[async_trait]
+pub trait RateLimitViolationSink: Send + Sync {
+    async fn record_violations_batch(
+        &self,
+        gateway_name: &str,
+        total_count: u64,
+        details: &serde_json::Value,
+    ) -> Result<()>;
+}
+
+#[cfg(feature = "test-support")]
+#[derive(Clone)]
+#[allow(dead_code)]
+pub struct ViolationRow {
+    pub gateway_name: String,
+    pub total_count: u64,
+    pub details: serde_json::Value,
+}
+
+#[cfg(feature = "test-support")]
+#[derive(Clone, Default)]
+pub struct InMemoryViolationSink {
+    rows: Arc<Mutex<Vec<ViolationRow>>>,
+}
+
+#[cfg(feature = "test-support")]
+impl InMemoryViolationSink {
+    #[allow(dead_code)]
+    pub async fn rows(&self) -> Vec<ViolationRow> {
+        self.rows.lock().await.clone()
+    }
+}
+
+#[cfg(feature = "test-support")]
+#[async_trait]
+impl RateLimitViolationSink for InMemoryViolationSink {
+    async fn record_violations_batch(
+        &self,
+        gateway_name: &str,
+        total_count: u64,
+        details: &serde_json::Value,
+    ) -> Result<()> {
+        let mut guard = self.rows.lock().await;
+        guard.push(ViolationRow {
+            gateway_name: gateway_name.to_string(),
+            total_count,
+            details: details.clone(),
+        });
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+#[allow(dead_code)]
+pub enum ViolationSinkHandle {
+    Database(Arc<Database>),
+    #[cfg(feature = "test-support")]
+    InMemory(InMemoryViolationSink),
+    Noop,
+}
+
+#[async_trait]
+impl RateLimitViolationSink for ViolationSinkHandle {
+    async fn record_violations_batch(
+        &self,
+        gateway_name: &str,
+        total_count: u64,
+        details: &serde_json::Value,
+    ) -> Result<()> {
+        match self {
+            ViolationSinkHandle::Database(db) => {
+                db.record_violations_batch(gateway_name, total_count, details)
+                    .await
+            }
+            #[cfg(feature = "test-support")]
+            ViolationSinkHandle::InMemory(sink) => {
+                sink.record_violations_batch(gateway_name, total_count, details)
+                    .await
+            }
+            ViolationSinkHandle::Noop => Ok(()),
+        }
+    }
+}
+
+#[async_trait]
+impl RateLimitViolationSink for Database {
+    async fn record_violations_batch(
+        &self,
+        gateway_name: &str,
+        total_count: u64,
+        details: &serde_json::Value,
+    ) -> Result<()> {
+        Database::record_violations_batch(self, gateway_name, total_count, details).await
     }
 }

--- a/src/db/repository.rs
+++ b/src/db/repository.rs
@@ -2,6 +2,7 @@ use anyhow::{Result, anyhow};
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use futures_util::SinkExt;
+use serde_json::Value as JsonValue;
 use tokio_postgres::types::ToSql;
 
 use super::connection::StmtKey;
@@ -127,6 +128,11 @@ reason, \
 gateway_name, \
 created_at\
 ) FROM STDIN WITH (FORMAT text)";
+
+    const Q_INSERT_RATE_LIMIT_VIOLATION: &'static str = r#"
+INSERT INTO rate_limit_violations (gateway_name, total_count, details)
+VALUES ($1, $2, $3)
+"#;
 
     pub async fn fetch_all_user_key_hashes(
         &self,
@@ -381,6 +387,25 @@ created_at\
                 Err(err)
             }
         }
+    }
+
+    /// Inserts a single aggregated rate-limit violation snapshot.
+    pub async fn record_violations_batch(
+        &self,
+        gateway_name: &str,
+        total_count: u64,
+        details: &JsonValue,
+    ) -> Result<()> {
+        let client = self.load_client().await?;
+        let count = total_count as i64;
+        client
+            .execute(
+                Self::Q_INSERT_RATE_LIMIT_VIOLATION,
+                &[&gateway_name, &count, details],
+            )
+            .await
+            .map_err(|e| anyhow!("Failed to insert rate-limit violation: {}", e))?;
+        Ok(())
     }
 }
 

--- a/src/db/violation_tracker.rs
+++ b/src/db/violation_tracker.rs
@@ -1,0 +1,269 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use scc::HashMap as SccHashMap;
+use serde_json::json;
+use tokio_util::sync::CancellationToken;
+use tracing::error;
+
+use super::RateLimitViolationSink;
+use super::ViolationSinkHandle;
+
+/// Key identifying a unique (client, limiter) pair for violation counting.
+///
+/// `client_id` is either a source-IP string (per-IP limiters) or a
+/// `"Subject:id"` string (distributed limiters).  `limiter` names the
+/// rate-limiter that triggered (e.g. `"basic"`, `"distributed:User"`).
+#[derive(Clone, Eq, PartialEq, Hash)]
+struct ViolationKey {
+    client_id: Arc<str>,
+    limiter: Arc<str>,
+}
+
+/// Accumulates rate-limit violations in memory and periodically flushes
+/// an aggregated snapshot to the configured sink.
+///
+/// Designed after [`super::EventRecorder`]: callers fire-and-forget via
+/// [`record`], and a background task drains the counters on an interval.
+/// Uses `scc::HashMap` with per-bucket locking for safe concurrent updates.
+#[derive(Clone)]
+pub struct RateLimitViolationTracker<S: RateLimitViolationSink = ViolationSinkHandle> {
+    sink: Arc<S>,
+    gateway_name: Arc<str>,
+    counters: Arc<SccHashMap<ViolationKey, u64>>,
+}
+
+impl<S: RateLimitViolationSink + 'static> RateLimitViolationTracker<S> {
+    pub fn new(
+        sink: Arc<S>,
+        gateway_name: Arc<str>,
+        flush_interval: Duration,
+        shutdown: CancellationToken,
+    ) -> Self {
+        let tracker = Self {
+            sink,
+            gateway_name,
+            counters: Arc::new(SccHashMap::default()),
+        };
+        tracker.spawn_flusher(flush_interval, shutdown);
+        tracker
+    }
+
+    /// Record a single rate-limit violation for the given limiter and client.
+    ///
+    /// Uses `entry_sync` which acquires a per-bucket lock so the
+    /// increment is safe under concurrent access without atomics.
+    pub fn record(&self, limiter: &str, client_id: &str) {
+        let key = ViolationKey {
+            client_id: Arc::from(client_id),
+            limiter: Arc::from(limiter),
+        };
+        self.counters
+            .entry_sync(key)
+            .and_modify(|v| *v += 1)
+            .or_insert(1);
+    }
+
+    fn spawn_flusher(&self, flush_interval: Duration, shutdown: CancellationToken) {
+        let sink = Arc::clone(&self.sink);
+        let counters = Arc::clone(&self.counters);
+        let gateway_name = Arc::clone(&self.gateway_name);
+        let token = shutdown.child_token();
+
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(flush_interval);
+            loop {
+                tokio::select! {
+                    _ = token.cancelled() => {
+                        let _ = Self::flush_once(&sink, &counters, &gateway_name).await;
+                        break;
+                    }
+                    _ = interval.tick() => {
+                        let _ = Self::flush_once(&sink, &counters, &gateway_name).await;
+                    }
+                }
+            }
+        });
+    }
+
+    async fn flush_once(
+        sink: &Arc<S>,
+        counters: &Arc<SccHashMap<ViolationKey, u64>>,
+        gateway_name: &str,
+    ) -> anyhow::Result<()> {
+        let mut details = serde_json::Map::new();
+        let mut total: u64 = 0;
+
+        // `retain_sync` visits every entry; returning `false` removes it.
+        // This atomically drains the map while collecting per-key counts.
+        counters.retain_sync(|key, val| {
+            if *val > 0 {
+                let label = format!("{}:{}", key.client_id, key.limiter);
+                details.insert(label, json!(*val));
+                total += *val;
+            }
+            false
+        });
+
+        if total == 0 {
+            return Ok(());
+        }
+
+        let details_value = serde_json::Value::Object(details);
+        if let Err(e) = sink
+            .record_violations_batch(gateway_name, total, &details_value)
+            .await
+        {
+            error!(error = ?e, "Failed to flush rate-limit violations");
+        }
+        Ok(())
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    #[allow(dead_code)]
+    pub async fn flush_once_for_test(&self) {
+        let _ = Self::flush_once(&self.sink, &self.counters, &self.gateway_name).await;
+    }
+
+    #[cfg(test)]
+    fn pending_total(&self) -> u64 {
+        let mut total = 0u64;
+        // Use retain to iterate without removing (always return true).
+        self.counters.retain_sync(|_, val| {
+            total += *val;
+            true
+        });
+        total
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Result;
+    use async_trait::async_trait;
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
+
+    #[derive(Clone)]
+    struct ViolationRow {
+        pub gateway_name: String,
+        pub total_count: u64,
+        pub details: serde_json::Value,
+    }
+
+    #[derive(Clone, Default)]
+    struct TestSink {
+        rows: Arc<Mutex<Vec<ViolationRow>>>,
+    }
+
+    #[async_trait]
+    impl RateLimitViolationSink for TestSink {
+        async fn record_violations_batch(
+            &self,
+            gateway_name: &str,
+            total_count: u64,
+            details: &serde_json::Value,
+        ) -> Result<()> {
+            self.rows.lock().await.push(ViolationRow {
+                gateway_name: gateway_name.to_string(),
+                total_count,
+                details: details.clone(),
+            });
+            Ok(())
+        }
+    }
+
+    fn build_tracker(sink: Arc<TestSink>) -> RateLimitViolationTracker<TestSink> {
+        let shutdown = CancellationToken::new();
+        RateLimitViolationTracker::new(
+            sink,
+            Arc::from("test-gw"),
+            Duration::from_secs(3600),
+            shutdown,
+        )
+    }
+
+    #[tokio::test]
+    async fn record_accumulates_counts() {
+        let sink = Arc::new(TestSink::default());
+        let tracker = build_tracker(Arc::clone(&sink));
+
+        tracker.record("basic", "10.0.0.1");
+        tracker.record("basic", "10.0.0.1");
+        tracker.record("result", "10.0.0.2");
+
+        assert_eq!(tracker.pending_total(), 3);
+    }
+
+    #[tokio::test]
+    async fn flush_writes_correct_snapshot() {
+        let sink = Arc::new(TestSink::default());
+        let tracker = build_tracker(Arc::clone(&sink));
+
+        tracker.record("basic", "10.0.0.1");
+        tracker.record("basic", "10.0.0.1");
+        tracker.record("distributed:User", "user-abc");
+
+        tracker.flush_once_for_test().await;
+
+        let rows = sink.rows.lock().await;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].gateway_name, "test-gw");
+        assert_eq!(rows[0].total_count, 3);
+
+        let details = rows[0].details.as_object().expect("details is object");
+        assert_eq!(details["10.0.0.1:basic"], json!(2));
+        assert_eq!(details["user-abc:distributed:User"], json!(1));
+    }
+
+    #[tokio::test]
+    async fn flush_clears_counters() {
+        let sink = Arc::new(TestSink::default());
+        let tracker = build_tracker(Arc::clone(&sink));
+
+        tracker.record("basic", "10.0.0.1");
+        tracker.flush_once_for_test().await;
+
+        assert_eq!(tracker.pending_total(), 0);
+
+        tracker.flush_once_for_test().await;
+        let rows = sink.rows.lock().await;
+        assert_eq!(rows.len(), 1, "empty flush should not produce a row");
+    }
+
+    #[tokio::test]
+    async fn empty_flush_produces_no_row() {
+        let sink = Arc::new(TestSink::default());
+        let tracker = build_tracker(Arc::clone(&sink));
+
+        tracker.flush_once_for_test().await;
+        let rows = sink.rows.lock().await;
+        assert!(rows.is_empty());
+    }
+
+    #[tokio::test]
+    async fn concurrent_records_are_consistent() {
+        let sink = Arc::new(TestSink::default());
+        let tracker = build_tracker(Arc::clone(&sink));
+        let n = 100u64;
+
+        let mut handles = Vec::new();
+        for _ in 0..n {
+            let t = tracker.clone();
+            handles.push(tokio::spawn(async move {
+                t.record("basic", "10.0.0.1");
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+
+        tracker.flush_once_for_test().await;
+
+        let rows = sink.rows.lock().await;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].total_count, n);
+        assert_eq!(rows[0].details["10.0.0.1:basic"], json!(n));
+    }
+}

--- a/src/http3/rate_limits.rs
+++ b/src/http3/rate_limits.rs
@@ -1,9 +1,11 @@
+use http::StatusCode;
 use salvo::prelude::*;
 use salvo::rate_limiter::{BasicQuota, FixedGuard, MokaStore, RateIssuer, RateLimiter};
 use std::sync::Arc;
 use uuid::Uuid;
 
 use crate::config::HTTPConfig;
+use crate::db::RateLimitViolationTracker;
 use crate::http3::depot_ext::DepotExt;
 use crate::http3::error::ServerError;
 use crate::http3::state::HttpState;
@@ -300,6 +302,25 @@ impl RateLimiters {
     }
 }
 
+/// Records a per-IP violation when the Salvo rate-limiter produced a 429 response.
+fn record_ip_violation_if_limited(
+    res: &Response,
+    req: &mut Request,
+    depot: &Depot,
+    state: &HttpState,
+    limiter_name: &str,
+) {
+    let is_429 = res
+        .status_code
+        .map(|s| s == StatusCode::TOO_MANY_REQUESTS)
+        .unwrap_or(false);
+    if !is_429 {
+        return;
+    }
+    let ip = cached_decimal_ip(req, depot).unwrap_or_else(|| Arc::from("unknown"));
+    state.violation_tracker().record(limiter_name, &ip);
+}
+
 #[handler]
 pub async fn basic_rate_limit(
     depot: &mut Depot,
@@ -313,6 +334,7 @@ pub async fn basic_rate_limit(
         .basic_limiter
         .handle(req, depot, res, ctrl)
         .await;
+    record_ip_violation_if_limited(res, req, depot, &state, "basic");
     Ok(())
 }
 
@@ -329,6 +351,7 @@ pub async fn update_key_rate_limit(
         .update_limiter
         .handle(req, depot, res, ctrl)
         .await;
+    record_ip_violation_if_limited(res, req, depot, &state, "update_key");
     Ok(())
 }
 
@@ -345,6 +368,7 @@ pub async fn unauthorized_only_rate_limit(
         .unauthorized_only_limiter
         .handle(req, depot, res, ctrl)
         .await;
+    record_ip_violation_if_limited(res, req, depot, &state, "unauthorized_only");
     Ok(())
 }
 
@@ -361,6 +385,7 @@ pub async fn read_rate_limit(
         .read_limiter
         .handle(req, depot, res, ctrl)
         .await;
+    record_ip_violation_if_limited(res, req, depot, &state, "read");
     Ok(())
 }
 
@@ -377,6 +402,7 @@ pub async fn result_rate_limit(
         .result_limiter
         .handle(req, depot, res, ctrl)
         .await;
+    record_ip_violation_if_limited(res, req, depot, &state, "add_result");
     Ok(())
 }
 
@@ -393,6 +419,7 @@ pub async fn load_rate_limit(
         .load_limiter
         .handle(req, depot, res, ctrl)
         .await;
+    record_ip_violation_if_limited(res, req, depot, &state, "load");
     Ok(())
 }
 
@@ -409,6 +436,7 @@ pub async fn leader_rate_limit(
         .leader_limiter
         .handle(req, depot, res, ctrl)
         .await;
+    record_ip_violation_if_limited(res, req, depot, &state, "leader");
     Ok(())
 }
 
@@ -425,6 +453,7 @@ pub async fn metric_rate_limit(
         .metric_limiter
         .handle(req, depot, res, ctrl)
         .await;
+    record_ip_violation_if_limited(res, req, depot, &state, "metric");
     Ok(())
 }
 
@@ -441,6 +470,7 @@ pub async fn status_rate_limit(
         .status_limiter
         .handle(req, depot, res, ctrl)
         .await;
+    record_ip_violation_if_limited(res, req, depot, &state, "status");
     Ok(())
 }
 
@@ -482,6 +512,7 @@ async fn check_subject_limit(
     gs: &GatewayState,
     epochs: (u64, u64),
     params: &SubjectParams<'_>,
+    violation_tracker: &RateLimitViolationTracker,
 ) -> Result<(), ServerError> {
     let subject = params.subject;
     let id = params.id;
@@ -521,6 +552,9 @@ async fn check_subject_limit(
         )
         .await
     {
+        let client_id = format!("{:?}:{}", subject, id);
+        let limiter_name = format!("distributed:{:?}", subject);
+        violation_tracker.record(&limiter_name, &client_id);
         return Err(ServerError::TooManyRequests(error_msg.to_string()));
     }
 
@@ -544,6 +578,7 @@ pub async fn reserve_add_task_rate_limit(
     let limiter = rate_limits.distributed().clone();
     let gs = state.gateway_state().clone();
     let policies = rate_limits.policies();
+    let violation_tracker = state.violation_tracker().clone();
 
     let epochs = limiter.epochs();
     let mut subjects = Vec::with_capacity(3);
@@ -567,7 +602,6 @@ pub async fn reserve_add_task_rate_limit(
         });
     }
 
-    // Company keys first, enforce their limits if present
     if let Some(company) = ctx.company.as_ref() {
         subjects.push(SubjectParams {
             subject: Subject::Company,
@@ -578,7 +612,6 @@ pub async fn reserve_add_task_rate_limit(
             require_day_match: company.daily_limit > 0,
         });
     } else if let Some(user_id) = ctx.user_id {
-        // Otherwise fall back to per-user quota when we have a user id
         subjects.push(SubjectParams {
             subject: Subject::User,
             id: user_id.as_u128(),
@@ -591,7 +624,9 @@ pub async fn reserve_add_task_rate_limit(
 
     let mut succeeded = Vec::with_capacity(subjects.len());
     for params in &subjects {
-        if let Err(err) = check_subject_limit(&limiter, &gs, epochs, params).await {
+        if let Err(err) =
+            check_subject_limit(&limiter, &gs, epochs, params, &violation_tracker).await
+        {
             for (key, (hour_decrement, day_decrement)) in succeeded.into_iter().rev() {
                 limiter
                     .rollback_pending(key, hour_decrement, day_decrement, epochs)

--- a/src/http3/server.rs
+++ b/src/http3/server.rs
@@ -130,6 +130,7 @@ impl Http3Server {
         gateway_state: GatewayState,
         task_queue: DupQueue<Task>,
         metrics: Metrics,
+        violation_tracker: crate::db::RateLimitViolationTracker,
         shutdown: CancellationToken,
     ) -> Result<Self> {
         let cfg = config.snapshot();
@@ -145,6 +146,7 @@ impl Http3Server {
             gateway_state: gateway_state.clone(),
             task_queue: task_queue.clone(),
             metrics: metrics.clone(),
+            violation_tracker,
         });
 
         let router = Self::setup_router(state)?;

--- a/src/http3/state.rs
+++ b/src/http3/state.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use crate::api::Task;
 use crate::common::queue::DupQueue;
 use crate::config_runtime::{RuntimeConfigStore, RuntimeConfigView};
+use crate::db::RateLimitViolationTracker;
 use crate::metrics::Metrics;
 use crate::raft::gateway_state::GatewayState;
 
@@ -13,6 +14,7 @@ pub struct HttpState {
     gateway_state: GatewayState,
     task_queue: DupQueue<Task>,
     metrics: Metrics,
+    violation_tracker: RateLimitViolationTracker,
 }
 
 pub struct HttpStateInit {
@@ -20,6 +22,7 @@ pub struct HttpStateInit {
     pub gateway_state: GatewayState,
     pub task_queue: DupQueue<Task>,
     pub metrics: Metrics,
+    pub violation_tracker: RateLimitViolationTracker,
 }
 
 impl HttpState {
@@ -29,12 +32,14 @@ impl HttpState {
             gateway_state,
             task_queue,
             metrics,
+            violation_tracker,
         } = init;
         Self {
             config,
             gateway_state,
             task_queue,
             metrics,
+            violation_tracker,
         }
     }
 
@@ -56,6 +61,10 @@ impl HttpState {
 
     pub fn metrics(&self) -> &Metrics {
         &self.metrics
+    }
+
+    pub fn violation_tracker(&self) -> &RateLimitViolationTracker {
+        &self.violation_tracker
     }
 
     pub fn is_cluster_ip(&self, ip: &IpAddr) -> bool {

--- a/src/raft/mod.rs
+++ b/src/raft/mod.rs
@@ -55,7 +55,10 @@ use crate::common::resolve::lookup_one_ip_per_host;
 use crate::config::NodeConfig;
 use crate::config_runtime::RuntimeConfigStore;
 use crate::crypto::crypto_provider::init_crypto_provider;
-use crate::db::{ApiKeyValidator, DatabaseBuilder, EventRecorder, EventSinkHandle};
+use crate::db::{
+    ApiKeyValidator, DatabaseBuilder, EventRecorder, EventSinkHandle, RateLimitViolationTracker,
+    ViolationSinkHandle,
+};
 use crate::http3::client::Http3Client;
 use crate::http3::client::Http3ClientBuilder;
 use crate::http3::server::Http3Server;
@@ -796,6 +799,15 @@ pub async fn start_gateway(
         gateway_shutdown.clone(),
     );
 
+    let violation_flush_interval = cfg.db.violation_flush_interval_sec.max(1);
+    let violation_sink = Arc::new(ViolationSinkHandle::Database(Arc::clone(&db)));
+    let violation_tracker = RateLimitViolationTracker::new(
+        violation_sink,
+        Arc::from(cfg.network.name.as_str()),
+        Duration::from_secs(violation_flush_interval),
+        gateway_shutdown.clone(),
+    );
+
     let api_key_validator_updater = tokio::spawn(ApiKeyValidator::run(
         Arc::clone(&api_key_validator),
         gateway_shutdown.clone(),
@@ -839,6 +851,7 @@ pub async fn start_gateway(
         gateway_state.clone(),
         task_queue.clone(),
         metrics.clone(),
+        violation_tracker,
         gateway_shutdown.clone(),
     )
     .await

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -33,7 +33,9 @@ use crate::common::queue::DupQueue;
 use crate::config::NodeConfig;
 use crate::config_runtime::RuntimeConfigStore;
 use crate::crypto::crypto_provider::init_crypto_provider;
-use crate::db::{ApiKeyValidator, Database, EventRecorder};
+use crate::db::{
+    ApiKeyValidator, Database, EventRecorder, RateLimitViolationTracker, ViolationSinkHandle,
+};
 use crate::metrics::Metrics;
 use crate::raft::store::RateLimitMutation;
 use crate::raft::{LogStore, StateMachineStore};
@@ -79,6 +81,7 @@ pub struct SharedHarnessCore {
     pub state: HttpState,
     pub runtime_config: Arc<RuntimeConfigStore>,
     pub config_path: PathBuf,
+    pub violation_tracker: RateLimitViolationTracker,
 }
 
 pub async fn build_shared_harness_core(
@@ -86,6 +89,7 @@ pub async fn build_shared_harness_core(
     config_path: PathBuf,
     event_recorder: EventRecorder,
     include_gateway_info: bool,
+    violation_sink: ViolationSinkHandle,
 ) -> SharedHarnessCore {
     let generic_key = config.http.generic_key.unwrap_or_else(Uuid::new_v4);
     let runtime_config = Arc::new(
@@ -200,11 +204,20 @@ pub async fn build_shared_harness_core(
         event_recorder,
     });
 
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    let violation_tracker = RateLimitViolationTracker::new(
+        Arc::new(violation_sink),
+        Arc::from(config.network.name.as_str()),
+        Duration::from_secs(3600),
+        shutdown,
+    );
+
     let state = HttpState::new(HttpStateInit {
         config: Arc::clone(&runtime_config),
         gateway_state,
         task_queue: task_queue.clone(),
         metrics,
+        violation_tracker: violation_tracker.clone(),
     });
 
     SharedHarnessCore {
@@ -215,6 +228,7 @@ pub async fn build_shared_harness_core(
         state,
         runtime_config,
         config_path,
+        violation_tracker,
     }
 }
 

--- a/tests/client_http_api/mod.rs
+++ b/tests/client_http_api/mod.rs
@@ -6,4 +6,5 @@ mod get_result;
 mod get_status;
 mod get_tasks;
 mod misc;
+mod rate_limit_violations;
 mod support;

--- a/tests/client_http_api/rate_limit_violations.rs
+++ b/tests/client_http_api/rate_limit_violations.rs
@@ -1,0 +1,146 @@
+use http::StatusCode;
+use salvo::test::TestClient;
+
+use gateway::db::ViolationRow;
+
+use crate::support::build_harness_with_violation_tracking;
+
+#[tokio::test]
+async fn basic_rate_limit_violations_are_tracked() {
+    let h = build_harness_with_violation_tracking().await;
+
+    // The basic_rate_limit on /add_task has a per-minute per-IP quota.
+    // Flood requests until we get 429, then verify tracker captured them.
+    let mut got_429 = false;
+    for _ in 0..200 {
+        let res = TestClient::post("http://localhost/add_task")
+            .add_header("x-api-key", h.api_key.to_string(), true)
+            .json(&serde_json::json!({"prompt": "hello world test"}))
+            .send(&h.service)
+            .await;
+        if res.status_code.unwrap_or(StatusCode::OK) == StatusCode::TOO_MANY_REQUESTS {
+            got_429 = true;
+            break;
+        }
+    }
+
+    assert!(got_429, "expected at least one 429 response");
+
+    // Flush the tracker to the in-memory sink.
+    h.violation_tracker.flush_once_for_test().await;
+
+    let rows: Vec<ViolationRow> = h.violation_sink.rows().await;
+    assert!(
+        !rows.is_empty(),
+        "violation sink should have at least one row after rate-limit trigger"
+    );
+
+    let row = &rows[0];
+    assert!(row.total_count >= 1);
+
+    let details = row.details.as_object().expect("details is JSON object");
+    assert!(
+        !details.is_empty(),
+        "details should contain at least one entry"
+    );
+}
+
+#[tokio::test]
+async fn no_violations_when_under_limit() {
+    let h = build_harness_with_violation_tracking().await;
+
+    let res = TestClient::post("http://localhost/add_task")
+        .add_header("x-api-key", h.api_key.to_string(), true)
+        .json(&serde_json::json!({"prompt": "hello world test"}))
+        .send(&h.service)
+        .await;
+
+    assert_eq!(res.status_code.unwrap(), StatusCode::OK);
+
+    h.violation_tracker.flush_once_for_test().await;
+
+    let rows: Vec<ViolationRow> = h.violation_sink.rows().await;
+    assert!(
+        rows.is_empty(),
+        "no violations expected when requests are within limits"
+    );
+}
+
+#[tokio::test]
+async fn distributed_rate_limit_violations_are_tracked() {
+    let h = build_harness_with_violation_tracking().await;
+
+    // The distributed rate limiter has per-user hourly limits.
+    // With the test config, the generic key global hourly limit is small.
+    // Flood /add_task until TooManyRequests.
+    let mut got_429 = false;
+    for _ in 0..500 {
+        let res = TestClient::post("http://localhost/add_task")
+            .add_header("x-api-key", h.api_key.to_string(), true)
+            .json(&serde_json::json!({"prompt": "hello distributed test"}))
+            .send(&h.service)
+            .await;
+        if res.status_code.unwrap_or(StatusCode::OK) == StatusCode::TOO_MANY_REQUESTS {
+            got_429 = true;
+            break;
+        }
+    }
+
+    if !got_429 {
+        // If the basic per-IP limiter is too tight we may not reach the
+        // distributed limit. That's acceptable -- we only assert if we did
+        // get a 429.
+        return;
+    }
+
+    h.violation_tracker.flush_once_for_test().await;
+    let rows: Vec<ViolationRow> = h.violation_sink.rows().await;
+    assert!(
+        !rows.is_empty(),
+        "violation sink should capture distributed-limiter violations"
+    );
+
+    let total: u64 = rows.iter().map(|r| r.total_count).sum();
+    assert!(total >= 1, "should have recorded at least one violation");
+}
+
+#[tokio::test]
+async fn multiple_flushes_produce_independent_rows() {
+    let h = build_harness_with_violation_tracking().await;
+
+    // Trigger some violations.
+    for _ in 0..200 {
+        let res = TestClient::post("http://localhost/add_task")
+            .add_header("x-api-key", h.api_key.to_string(), true)
+            .json(&serde_json::json!({"prompt": "batch test"}))
+            .send(&h.service)
+            .await;
+        if res.status_code.unwrap_or(StatusCode::OK) == StatusCode::TOO_MANY_REQUESTS {
+            break;
+        }
+    }
+
+    h.violation_tracker.flush_once_for_test().await;
+
+    // Trigger more violations.
+    for _ in 0..50 {
+        let _ = TestClient::post("http://localhost/add_task")
+            .add_header("x-api-key", h.api_key.to_string(), true)
+            .json(&serde_json::json!({"prompt": "batch test 2"}))
+            .send(&h.service)
+            .await;
+    }
+
+    h.violation_tracker.flush_once_for_test().await;
+
+    let rows: Vec<ViolationRow> = h.violation_sink.rows().await;
+    // If rate limits were triggered in both rounds, we get two rows.
+    // If only the first round triggered, we get one row.
+    // Either way, the second flush should not duplicate the first batch.
+    if rows.len() >= 2 {
+        assert_ne!(
+            rows[0].details, rows[1].details,
+            "each flush should produce independent snapshots"
+        );
+    }
+}

--- a/tests/client_http_api/support.rs
+++ b/tests/client_http_api/support.rs
@@ -19,7 +19,10 @@ use gateway::common::queue::DupQueue;
 use gateway::config::NodeConfig;
 use gateway::config_runtime::RuntimeConfigStore;
 use gateway::crypto::hotkey::Hotkey;
-use gateway::db::{EventRecorder, EventSinkHandle};
+use gateway::db::{
+    EventRecorder, EventSinkHandle, InMemoryViolationSink, RateLimitViolationTracker,
+    ViolationSinkHandle,
+};
 use gateway::task::TaskManager;
 use gateway::test_support::{
     MultipartFilePart, add_task_handler, api_or_generic_key_check, basic_rate_limit,
@@ -203,6 +206,7 @@ async fn build_harness_inner(
         config_path.clone(),
         event_recorder,
         include_gateway,
+        ViolationSinkHandle::Noop,
     )
     .await;
 
@@ -269,6 +273,95 @@ async fn build_harness_inner(
 impl Drop for TestHarness {
     fn drop(&mut self) {
         self.shutdown.cancel();
+    }
+}
+
+pub(crate) struct ViolationTestHarness {
+    pub(crate) service: Service,
+    pub(crate) api_key: Uuid,
+    pub(crate) violation_tracker: RateLimitViolationTracker,
+    pub(crate) violation_sink: InMemoryViolationSink,
+    pub(crate) shutdown: CancellationToken,
+    pub(crate) _config_file: NamedTempFile,
+}
+
+impl Drop for ViolationTestHarness {
+    fn drop(&mut self) {
+        self.shutdown.cancel();
+    }
+}
+
+/// Builds a test harness wired with an `InMemoryViolationSink` so tests
+/// can flush and assert on recorded rate-limit violations.
+pub(crate) async fn build_harness_with_violation_tracking() -> ViolationTestHarness {
+    ensure_crypto_provider();
+
+    let (config, _config_path) = load_config();
+    let config = Arc::new(config);
+    let config_file = tempfile::Builder::new()
+        .suffix(".toml")
+        .tempfile()
+        .expect("temp config file");
+    let config_toml = toml::to_string(config.as_ref()).expect("serialize test config");
+    std::fs::write(config_file.path(), config_toml).expect("write temp config");
+    let config_path = config_file.path().to_path_buf();
+
+    let shutdown = CancellationToken::new();
+
+    let event_sink = Arc::new(EventSinkHandle::Noop);
+    let events_flush_interval = config.db.events_flush_interval_sec.max(1);
+    let events_queue_capacity = config.db.events_queue_capacity.max(1);
+
+    let event_recorder = EventRecorder::new(
+        Arc::clone(&event_sink),
+        Arc::from(config.network.name.as_str()),
+        Duration::from_secs(events_flush_interval),
+        events_queue_capacity,
+        shutdown.clone(),
+    );
+
+    let violation_sink = InMemoryViolationSink::default();
+    let core = build_shared_harness_core(
+        Arc::clone(&config),
+        config_path,
+        event_recorder,
+        true,
+        ViolationSinkHandle::InMemory(violation_sink.clone()),
+    )
+    .await;
+
+    let state = core.state;
+
+    let router = Router::new()
+        .hoop(affix_state::inject(state))
+        .hoop(prepare_rate_limit_context)
+        .push(
+            Router::with_path("/add_task")
+                .hoop(dynamic_add_task_size_limit)
+                .hoop(basic_rate_limit)
+                .hoop(api_or_generic_key_check)
+                .post(add_task_handler),
+        )
+        .push(
+            Router::with_path("/get_version")
+                .hoop(dynamic_request_size_limit)
+                .get(version_handler),
+        )
+        .push(
+            Router::with_path("/id")
+                .hoop(dynamic_request_size_limit)
+                .get(id_handler),
+        );
+
+    let service = Service::new(router).catcher(Catcher::default().hoop(custom_response));
+
+    ViolationTestHarness {
+        service,
+        api_key: core.generic_key,
+        violation_tracker: core.violation_tracker,
+        violation_sink,
+        shutdown,
+        _config_file: config_file,
     }
 }
 

--- a/tests/event_tracker/support.rs
+++ b/tests/event_tracker/support.rs
@@ -16,7 +16,8 @@ use gateway::common::queue::DupQueue;
 use gateway::config::NodeConfig;
 use gateway::crypto::hotkey::Hotkey;
 use gateway::db::{
-    ActivityEventRow, EventRecorder, EventSinkHandle, InMemoryEventSink, WorkerEventRow,
+    ActivityEventRow, EventRecorder, EventSinkHandle, InMemoryEventSink, ViolationSinkHandle,
+    WorkerEventRow,
 };
 use gateway::task::TaskManager;
 use gateway::test_support::{
@@ -189,6 +190,7 @@ pub(crate) async fn build_harness(
         config_path,
         event_recorder.clone(),
         true,
+        ViolationSinkHandle::Noop,
     )
     .await;
 


### PR DESCRIPTION
## Rate Limit Violation Tracking

### Summary

Adds batched rate-limit violation tracking that accumulates per-client violations in memory and periodically flushes them to a dedicated PostgreSQL table. This avoids spamming the database with individual violation records on hot paths.

### Motivation

Previously, rate limit violations were only observable through HTTP 429 responses. There was no persistent record of how often limits were hit, by which clients, or through which limiters. This makes it difficult to tune rate limits, detect abuse patterns, or understand capacity pressure across gateway instances.

### Design

The implementation follows the existing `EventRecorder` / `EventSink` pattern already used for activity and worker events:

- **In-memory accumulator** (`RateLimitViolationTracker`) -- uses `scc::HashMap` with per-bucket locking for contention-free `record()` calls on hot request paths. A background task drains the map on a configurable interval (default 60s).
- **Sink trait** (`RateLimitViolationSink`) -- abstracts persistence so tests can use `InMemoryViolationSink` or `Noop` without a database.
- **Database table** (`rate_limit_violations`) -- each flush produces one row per gateway instance with `gateway_name`, `total_count`, and a `details` JSONB column mapping `"client_id:limiter_name"` to count.

### Integration points

Violations are captured at both rate-limiting layers:

1. **Per-IP Salvo middleware** -- after each `limiter.handle()` call, the response status is checked; if 429, the violation is recorded with the source IP and limiter name (`basic`, `add_result`, `load`, `leader`, `metric`, `status`, `update_key`, `unauthorized_only`, `read`).
2. **Distributed subject-based limiter** -- when `check_and_incr` returns `false` in `check_subject_limit`, the violation is recorded with the subject type and ID before returning `TooManyRequests`.

### Changes

- `dev-env/init-scripts/init-schema.sql` -- new `rate_limit_violations` table with index on `(gateway_name, created_at DESC)`
- `Cargo.toml` -- added `with-serde_json-1` feature to `tokio-postgres` for JSONB parameter support
- `src/config.rs` -- added `violation_flush_interval_sec` field to `DbConfig` (default 60s)
- `src/db/mod.rs` -- `RateLimitViolationSink` trait, `InMemoryViolationSink`, `ViolationSinkHandle` enum, `ViolationRow`
- `src/db/repository.rs` -- `Database::record_violations_batch` INSERT query
- `src/db/violation_tracker.rs` -- **new file**: `RateLimitViolationTracker` struct with accumulator + periodic flusher + 5 unit tests
- `src/http3/rate_limits.rs` -- `record_ip_violation_if_limited` helper; hooks in all 9 per-IP handlers and `check_subject_limit`
- `src/http3/state.rs` -- `violation_tracker` field + accessor on `HttpState`
- `src/http3/server.rs` -- pass tracker through `Http3Server::run`
- `src/raft/mod.rs` -- create tracker at startup alongside `EventRecorder`
- `src/test_support.rs` -- accept `ViolationSinkHandle` in `build_shared_harness_core`
- `tests/client_http_api/support.rs` -- `ViolationTestHarness` + `build_harness_with_violation_tracking`
- `tests/client_http_api/rate_limit_violations.rs` -- **new file**: 4 integration tests
- `tests/event_tracker/support.rs` -- pass `ViolationSinkHandle::Noop` to updated harness builder
- `dev-env/config/*.toml` -- added `violation_flush_interval_sec = 60` to all dev configs

### Database migration

Run manually on existing deployments before deploying:

```sql
CREATE TABLE IF NOT EXISTS rate_limit_violations (
  id BIGSERIAL PRIMARY KEY,
  gateway_name VARCHAR(255) NOT NULL,
  total_count BIGINT NOT NULL,
  details JSONB NOT NULL DEFAULT '{}',
  created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT (NOW() AT TIME ZONE 'UTC')
);
CREATE INDEX IF NOT EXISTS idx_rlv_gateway_created
  ON rate_limit_violations(gateway_name, created_at DESC);