### PR TITLE
Fix tracking, improve generic key handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arg_enum_proc_macro"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2417,6 +2426,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2932,9 +2942,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc89deee4af0429081d2a518c0431ae068222a5a262a3bc6ff4d8535ec2e02fe"
+checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
 dependencies = [
  "cc",
 ]
@@ -2965,9 +2975,9 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "local-ip-address"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a59a0cb1c7f84471ad5cd38d768c2a29390d17f1ff2827cdf49bc53e8ac70b"
+checksum = "d7b0187df4e614e42405b49511b82ff7a1774fbd9a816060ee465067847cac22"
 dependencies = [
  "libc",
  "neli",
@@ -3056,9 +3066,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc"
-version = "0.1.49"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aca3c01a711f395b4257b81674c0e90e8dd1f1e62c4b7db45f684cc7a4fcb18a"
+checksum = "b3627c4272df786b9260cabaa46aec1d59c93ede723d4c3ef646c503816b0640"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -3461,9 +3471,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openraft"
-version = "0.9.22"
+version = "0.9.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2f40b0e23149ea8673591325bff055939f7a59f4f9a28476f0854282444ab3"
+checksum = "80d35e2f60cdf9bcfc39a020966091017c6dc2a4b43b355a22ca3e76106f4a0a"
 dependencies = [
  "anyerror",
  "byte-unit",
@@ -3484,9 +3494,9 @@ dependencies = [
 
 [[package]]
 name = "openraft-macros"
-version = "0.9.22"
+version = "0.9.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b0033052d96bc535b99ea1f38973fad984ed658940bbd27ff59c377cada11c"
+checksum = "bbbf0342d747a8da209c8e1d3ca8f788100966669412aaacb449409205931251"
 dependencies = [
  "chrono",
  "proc-macro2",
@@ -4589,9 +4599,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -4619,9 +4629,9 @@ checksum = "bd8d438861332c3b1ac396c77bd9cac620ea1ff347efb63c05a83d8f0a593899"
 
 [[package]]
 name = "salvo"
-version = "0.91.1"
+version = "0.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77fab67d0b522290dd88006cb84b4462d83d6a7125c71da6826cd333618ab21b"
+checksum = "18c769247c3d1f0334876337eb5044e8954d7546ee8814adef31eb9b6343a569"
 dependencies = [
  "salvo-acme",
  "salvo-compression",
@@ -4633,9 +4643,9 @@ dependencies = [
 
 [[package]]
 name = "salvo-acme"
-version = "0.91.1"
+version = "0.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a43a49607643e6b21e5b628d1ebc19fe251aebe501167433cfb587ef94e3843"
+checksum = "db676595526cc23d157e31adf89bb32640f7cbb1ca2b19d83449eb6ff037cff5"
 dependencies = [
  "certon",
  "futures-util",
@@ -4648,9 +4658,9 @@ dependencies = [
 
 [[package]]
 name = "salvo-compression"
-version = "0.91.1"
+version = "0.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6076264c095d07f0c1574f09e273ade1fede70df8223d9c4c8a5c5a95cc2c7e"
+checksum = "d3148cb9a9cd371e594a7aae6cb922818cc102e0d1825cf3014c7befa3a05791"
 dependencies = [
  "brotli",
  "bytes",
@@ -4683,9 +4693,9 @@ dependencies = [
 
 [[package]]
 name = "salvo-proxy"
-version = "0.91.1"
+version = "0.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56a0e8fc349f25e0eecc410ea71feee3f1312bdbbf5fb31ad889a47d8285645"
+checksum = "12106182d3a59907a07f8cab1502de7a96e5acd5b899b66397975ac01e3f9c48"
 dependencies = [
  "fastrand",
  "futures-util",
@@ -4702,9 +4712,9 @@ dependencies = [
 
 [[package]]
 name = "salvo-rate-limiter"
-version = "0.91.1"
+version = "0.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb9acd4dc6cc1753f8b1a2135608e8a0ba46fa004721064d4ba5fa94763b4309"
+checksum = "4bd48fb32aefb9909e2916874826bf9fe7d98e6bfb0b305f6b0aebdc4e17f41f"
 dependencies = [
  "moka",
  "salvo_core",
@@ -4716,9 +4726,9 @@ dependencies = [
 
 [[package]]
 name = "salvo-serde-util"
-version = "0.91.1"
+version = "0.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ea8e3129e2ce49e13b7e278dbce21edb777fcb161b4975da5b372457de0487"
+checksum = "9158501312da84612279015f3c7793e40c80b8fd6628823fba9bf1bcaad197e6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4727,10 +4737,11 @@ dependencies = [
 
 [[package]]
 name = "salvo_core"
-version = "0.91.1"
+version = "0.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99029932828083aeb4cebd8e0e977323382423b0c305dfb4dc7b8473034467d8"
+checksum = "1193415bc0b50b041bf5b3a1e2d066332d9be4bb6a31b6775e6b3afddb3d6926"
 dependencies = [
+ "arc-swap",
  "async-trait",
  "base64 0.22.1",
  "brotli",
@@ -4780,9 +4791,9 @@ dependencies = [
 
 [[package]]
 name = "salvo_extra"
-version = "0.91.1"
+version = "0.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "672456a8d426b13efd7cfc574ffb408cd9ba91e7d4e7d963360d906d6817dee6"
+checksum = "c09fedc4b2c0195e250b2e27e7888faa32245d0c4ec93e178273c16b178c26ce"
 dependencies = [
  "base64 0.22.1",
  "etag",
@@ -4802,9 +4813,9 @@ dependencies = [
 
 [[package]]
 name = "salvo_macros"
-version = "0.91.1"
+version = "0.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b082312da8e9a8f45d767d78ded6688005eb582272e5fc858d235d696aa02cb"
+checksum = "2e48a1b12532532f2193aaf0fec67a8f31542fb2b5f46108328297629011697f"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6350,6 +6361,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6699,9 +6719,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 build = "src/build.rs"
 
 [dependencies]
-salvo = { version = "0.91.1", features = [
+salvo = { version = "0.92.0", features = [
     "quinn",
     "rustls",
     "rate-limiter",
@@ -45,7 +45,7 @@ h3 = { version = "0.0.8", features = ["tracing"] }
 h3-quinn = { version = "0.0.10" }
 http = "1.4.0"
 backon = "1.6.0"
-openraft = { version = "0.9.22", features = ["storage-v2", "serde"] }
+openraft = { version = "0.9.24", features = ["storage-v2", "serde"] }
 tokio-postgres-rustls = "0.13.0"
 rustls = { version = "0.23.38" }
 rustls-platform-verifier = "0.7.0"
@@ -60,7 +60,7 @@ rcgen = { version = "0.14.7", features = ["pem"] }
 foldhash = "0.2.0"
 portable-atomic = "1.13.1"
 scc = "3.7.0"
-sdd = "4.8.3"
+sdd = "4.8.6"
 schnorrkel = "0.11.5"
 base64-simd = "0.8"
 blake2 = "0.10.6"
@@ -68,7 +68,7 @@ bs58 = "0.5.1"
 prometheus = "0.14.0"
 blake3 = "1.8.4"
 moka = { version = "0.12.15", features = ["sync"] }
-mimalloc = { version = "0.1.48", default-features = false }
+mimalloc = { version = "0.1.50", default-features = false }
 regex = "1.12.3"
 image = "0.25.10"
 chrono = { version = "0.4", features = ["serde", "clock"] }

--- a/dev-env/config/config-single.toml
+++ b/dev-env/config/config-single.toml
@@ -26,7 +26,7 @@ basic_rate_limit = 30
 # 1) Missing/invalid/unknown API key on /add_task:
 #    add_task_unauthorized_per_ip_daily_rate_limit (per source IP, daily)
 # 2) Valid generic key (http.generic_key):
-#    uses SQL-backed guest rolling-window limits from gen's app_settings row
+#    uses gateway-configured shared concurrency plus SQL-backed guest rolling-window limits
 # 3) Valid non-company user key:
 #    uses DB-configured per-user concurrent and daily limits
 # There is no separate unauthorized-global cap; unauthorized traffic is per-IP only.
@@ -46,6 +46,8 @@ signature_freshness_threshold = 30
 max_task_queue_len = 500
 admin_key = "b6c8597a-00e9-493a-b6cd-5dfc7244d46b"
 generic_key = "6eca4068-3be6-4d30-b828-f63cda3bc35b"
+# Shared active-task cap for the generic key across all source IPs.
+generic_key_concurrent_limit = 2
 api_key_secret = "CHANGE_ME_IN_PRODUCTION_58392047"
 invalid_api_key_negative_cache_ttl_sec = 300
 invalid_api_key_ip_miss_ttl_sec = 600

--- a/dev-env/config/config1.toml
+++ b/dev-env/config/config1.toml
@@ -26,7 +26,7 @@ basic_rate_limit = 30
 # 1) Missing/invalid/unknown API key on /add_task:
 #    add_task_unauthorized_per_ip_daily_rate_limit (per source IP, daily)
 # 2) Valid generic key (http.generic_key):
-#    uses SQL-backed guest rolling-window limits from gen's app_settings row
+#    uses gateway-configured shared concurrency plus SQL-backed guest rolling-window limits
 # 3) Valid non-company user key:
 #    uses DB-configured per-user concurrent and daily limits
 # There is no separate unauthorized-global cap; unauthorized traffic is per-IP only.
@@ -46,6 +46,8 @@ signature_freshness_threshold = 30
 max_task_queue_len = 500
 admin_key = "b6c8597a-00e9-493a-b6cd-5dfc7244d46b"
 generic_key = "6eca4068-3be6-4d30-b828-f63cda3bc35b"
+# Shared active-task cap for the generic key across all source IPs.
+generic_key_concurrent_limit = 2
 api_key_secret = "CHANGE_ME_IN_PRODUCTION_58392047"
 invalid_api_key_negative_cache_ttl_sec = 300
 invalid_api_key_ip_miss_ttl_sec = 600

--- a/dev-env/config/config2.toml
+++ b/dev-env/config/config2.toml
@@ -26,7 +26,7 @@ basic_rate_limit = 30
 # 1) Missing/invalid/unknown API key on /add_task:
 #    add_task_unauthorized_per_ip_daily_rate_limit (per source IP, daily)
 # 2) Valid generic key (http.generic_key):
-#    uses SQL-backed guest rolling-window limits from gen's app_settings row
+#    uses gateway-configured shared concurrency plus SQL-backed guest rolling-window limits
 # 3) Valid non-company user key:
 #    uses DB-configured per-user concurrent and daily limits
 # There is no separate unauthorized-global cap; unauthorized traffic is per-IP only.
@@ -46,6 +46,8 @@ signature_freshness_threshold = 30
 max_task_queue_len = 500
 admin_key = "b6c8597a-00e9-493a-b6cd-5dfc7244d46b"
 generic_key = "6eca4068-3be6-4d30-b828-f63cda3bc35b"
+# Shared active-task cap for the generic key across all source IPs.
+generic_key_concurrent_limit = 2
 api_key_secret = "CHANGE_ME_IN_PRODUCTION_58392047"
 invalid_api_key_negative_cache_ttl_sec = 300
 invalid_api_key_ip_miss_ttl_sec = 600

--- a/dev-env/config/config3.toml
+++ b/dev-env/config/config3.toml
@@ -26,7 +26,7 @@ basic_rate_limit = 30
 # 1) Missing/invalid/unknown API key on /add_task:
 #    add_task_unauthorized_per_ip_daily_rate_limit (per source IP, daily)
 # 2) Valid generic key (http.generic_key):
-#    uses SQL-backed guest rolling-window limits from gen's app_settings row
+#    uses gateway-configured shared concurrency plus SQL-backed guest rolling-window limits
 # 3) Valid non-company user key:
 #    uses DB-configured per-user concurrent and daily limits
 # There is no separate unauthorized-global cap; unauthorized traffic is per-IP only.
@@ -46,6 +46,8 @@ signature_freshness_threshold = 30
 max_task_queue_len = 500
 admin_key = "b6c8597a-00e9-493a-b6cd-5dfc7244d46b"
 generic_key = "6eca4068-3be6-4d30-b828-f63cda3bc35b"
+# Shared active-task cap for the generic key across all source IPs.
+generic_key_concurrent_limit = 2
 api_key_secret = "CHANGE_ME_IN_PRODUCTION_58392047"
 invalid_api_key_negative_cache_ttl_sec = 300
 invalid_api_key_ip_miss_ttl_sec = 600

--- a/dev-env/init-scripts/init-schema.sql
+++ b/dev-env/init-scripts/init-schema.sql
@@ -3180,12 +3180,10 @@ REVOKE ALL ON FUNCTION generation_purge_terminal_tasks(INTEGER, BIGINT) FROM PUB
 
 CREATE TABLE IF NOT EXISTS activity_events (
   id BIGSERIAL PRIMARY KEY,
-  task_id UUID REFERENCES generation_tasks(id) ON DELETE SET NULL,
-  account_id BIGINT REFERENCES accounts(id) ON DELETE SET NULL,
-  user_id BIGINT REFERENCES users(id) ON DELETE SET NULL,
-  company_id UUID REFERENCES companies(id) ON DELETE SET NULL,
-  api_key_id BIGINT REFERENCES api_keys(id) ON DELETE SET NULL,
-  session_id TEXT REFERENCES sessions(id) ON DELETE SET NULL,
+  task_id UUID,
+  account_id BIGINT,
+  user_id BIGINT,
+  company_id UUID,
   action TEXT NOT NULL,
   event_family TEXT NOT NULL DEFAULT 'other' CHECK (event_family IN ('auth', 'other')),
   client_origin TEXT NOT NULL DEFAULT 'website',
@@ -3211,10 +3209,6 @@ CREATE INDEX IF NOT EXISTS activity_events_user_created_idx
 CREATE INDEX IF NOT EXISTS activity_events_company_created_idx
   ON activity_events (company_id, created_at DESC)
   WHERE company_id IS NOT NULL;
-
-CREATE INDEX IF NOT EXISTS activity_events_session_id_idx
-  ON activity_events (session_id)
-  WHERE session_id IS NOT NULL;
 
 CREATE INDEX IF NOT EXISTS activity_events_action_created_idx
   ON activity_events (action, created_at DESC);
@@ -3255,7 +3249,7 @@ CREATE INDEX IF NOT EXISTS stripe_webhook_events_status_updated_idx
 
 CREATE TABLE IF NOT EXISTS worker_events (
   id BIGSERIAL PRIMARY KEY,
-  task_id UUID REFERENCES generation_tasks(id) ON DELETE SET NULL,
+  task_id UUID,
   worker_id TEXT,
   action TEXT NOT NULL,
   task_kind TEXT NOT NULL,

--- a/src/config.rs
+++ b/src/config.rs
@@ -139,6 +139,9 @@ pub struct HTTPConfig {
     pub admin_key: Uuid,
     // Fallback generic key used until the database-backed app_settings cache loads.
     pub generic_key: Option<Uuid>,
+    // Shared concurrent active task cap for the generic key. Set 0 to disable the active-slot cap.
+    #[serde(default = "default_generic_key_concurrent_limit")]
+    pub generic_key_concurrent_limit: usize,
     // Secret used to key BLAKE3 for API key verification
     pub api_key_secret: String,
     #[serde(default = "default_invalid_api_key_negative_cache_ttl_sec")]
@@ -242,6 +245,10 @@ fn default_max_concurrent_image_uploads() -> usize {
 
 fn default_distributed_rate_limiter_max_capacity() -> usize {
     4096
+}
+
+fn default_generic_key_concurrent_limit() -> usize {
+    2
 }
 
 fn default_invalid_api_key_negative_cache_ttl_sec() -> u64 {
@@ -517,5 +524,35 @@ pub fn resolve_config_path(path: Option<&String>) -> Result<PathBuf> {
         Ok(json_path.to_path_buf())
     } else {
         Err(anyhow!("No configuration file found"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::NodeConfig;
+
+    fn read_config_single() -> String {
+        let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("dev-env/config/config-single.toml");
+        std::fs::read_to_string(path).expect("read config-single.toml")
+    }
+
+    #[test]
+    fn http_config_defaults_generic_key_concurrent_limit_when_missing() {
+        let config_text = read_config_single().replace("generic_key_concurrent_limit = 2\n", "");
+        let config: NodeConfig =
+            toml::from_str(&config_text).expect("parse config without override");
+        assert_eq!(config.http.generic_key_concurrent_limit, 2);
+    }
+
+    #[test]
+    fn http_config_reads_generic_key_concurrent_limit_override() {
+        let config_text = read_config_single().replacen(
+            "generic_key_concurrent_limit = 2",
+            "generic_key_concurrent_limit = 3",
+            1,
+        );
+        let config: NodeConfig = toml::from_str(&config_text).expect("parse config with override");
+        assert_eq!(config.http.generic_key_concurrent_limit, 3);
     }
 }

--- a/src/db/connection.rs
+++ b/src/db/connection.rs
@@ -44,6 +44,7 @@ pub(super) enum StmtKey {
     GenerationPurgeTerminalTasks,
     GenerationTaskAccountId,
     GenerationTaskStatusSnapshot,
+    GenerationTaskGenericKeyHash,
 }
 
 const POSTGRES_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
@@ -898,6 +899,7 @@ impl Database {
             StmtKey::GenerationPurgeTerminalTasks => Self::Q_GENERATION_PURGE_TERMINAL_TASKS,
             StmtKey::GenerationTaskAccountId => Self::Q_GENERATION_TASK_ACCOUNT_ID,
             StmtKey::GenerationTaskStatusSnapshot => Self::Q_GENERATION_TASK_STATUS_SNAPSHOT,
+            StmtKey::GenerationTaskGenericKeyHash => Self::Q_GENERATION_TASK_GENERIC_KEY_HASH,
         }
     }
 

--- a/src/db/data_access.rs
+++ b/src/db/data_access.rs
@@ -165,15 +165,11 @@ fn encode_activity_event_copy_row(buf: &mut Vec<u8>, row: &ActivityEventRow) {
     .to_string();
     append_copy_field(buf, row.task_id.map(|v| v.to_string()).as_deref());
     buf.push(b'\t');
-    append_copy_field(buf, None);
+    append_copy_field(buf, row.account_id.map(|v| v.to_string()).as_deref());
     buf.push(b'\t');
     append_copy_field(buf, row.user_id.map(|v| v.to_string()).as_deref());
     buf.push(b'\t');
     append_copy_field(buf, row.company_id.map(|v| v.to_string()).as_deref());
-    buf.push(b'\t');
-    append_copy_field(buf, None);
-    buf.push(b'\t');
-    append_copy_field(buf, None);
     buf.push(b'\t');
     append_copy_field(buf, Some(row.action.as_str()));
     buf.push(b'\t');
@@ -195,6 +191,7 @@ fn encode_activity_event_copy_row(buf: &mut Vec<u8>, row: &ActivityEventRow) {
 }
 
 fn encode_worker_event_copy_row(buf: &mut Vec<u8>, row: &WorkerEventRow) {
+    let metadata_json = row.metadata_json.to_string();
     append_copy_field(buf, row.task_id.map(|v| v.to_string()).as_deref());
     buf.push(b'\t');
     append_copy_field(buf, row.worker_id.as_deref());
@@ -203,13 +200,13 @@ fn encode_worker_event_copy_row(buf: &mut Vec<u8>, row: &WorkerEventRow) {
     buf.push(b'\t');
     append_copy_field(buf, Some(row.task_kind.as_str()));
     buf.push(b'\t');
-    append_copy_field(buf, None);
+    append_copy_field(buf, row.model.as_deref());
     buf.push(b'\t');
     append_copy_field(buf, row.reason.as_deref());
     buf.push(b'\t');
     append_copy_field(buf, Some(row.gateway_name.as_str()));
     buf.push(b'\t');
-    append_copy_field(buf, Some("{}"));
+    append_copy_field(buf, Some(metadata_json.as_str()));
     buf.push(b'\t');
     let created_at = row.created_at.timestamp_millis().to_string();
     append_copy_field(buf, Some(created_at.as_str()));
@@ -457,8 +454,6 @@ task_id, \
 account_id, \
 user_id, \
 company_id, \
-api_key_id, \
-session_id, \
 action, \
 event_family, \
 client_origin, \

--- a/src/db/event_recorder.rs
+++ b/src/db/event_recorder.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
 use chrono::Utc;
@@ -8,8 +7,6 @@ use tracing::error;
 use uuid::Uuid;
 
 use crate::db::{ActivityEventRow, EventSink, EventSinkHandle, WorkerEventRow};
-
-const MAX_RETRY_ATTEMPTS: u32 = 8;
 
 #[derive(Clone)]
 enum EventRow {
@@ -40,8 +37,6 @@ pub struct EventRecorder<S: EventSink = EventSinkHandle> {
     gateway_name: Arc<str>,
     queue: Arc<scc::Queue<QueuedEventRow>>,
     capacity: usize,
-    dropped: Arc<AtomicUsize>,
-    dead_lettered: Arc<AtomicUsize>,
 }
 
 impl<S: EventSink + 'static> EventRecorder<S> {
@@ -58,8 +53,6 @@ impl<S: EventSink + 'static> EventRecorder<S> {
             gateway_name,
             queue: Arc::new(scc::Queue::default()),
             capacity,
-            dropped: Arc::new(AtomicUsize::new(0)),
-            dead_lettered: Arc::new(AtomicUsize::new(0)),
         };
         recorder.spawn_flusher(flush_interval, shutdown);
         recorder
@@ -70,6 +63,7 @@ impl<S: EventSink + 'static> EventRecorder<S> {
         &self,
         user_id: Option<i64>,
         user_email: Option<&str>,
+        account_id: Option<i64>,
         company_id: Option<Uuid>,
         company_name: Option<&str>,
         action: &str,
@@ -81,6 +75,7 @@ impl<S: EventSink + 'static> EventRecorder<S> {
         let row = ActivityEventRow {
             user_id,
             user_email: user_email.map(|v| v.to_string()),
+            account_id,
             company_id,
             company_name: company_name.map(|v| v.to_string()),
             action: action.to_string(),
@@ -101,15 +96,21 @@ impl<S: EventSink + 'static> EventRecorder<S> {
         worker_id: Option<&str>,
         action: &str,
         task_kind: &str,
+        model: Option<&str>,
         reason: Option<&str>,
+        metadata_json: Option<&serde_json::Value>,
     ) {
         let row = WorkerEventRow {
             task_id,
             worker_id: worker_id.map(|v| v.to_string()),
             action: action.to_string(),
             task_kind: task_kind.to_string(),
+            model: model.map(|v| v.to_string()),
             reason: reason.map(|v| v.to_string()),
             gateway_name: self.gateway_name.to_string(),
+            metadata_json: metadata_json
+                .cloned()
+                .unwrap_or_else(|| serde_json::json!({})),
             created_at: Utc::now(),
         };
         self.enqueue(EventRow::Worker(row));
@@ -119,8 +120,6 @@ impl<S: EventSink + 'static> EventRecorder<S> {
         let sink = Arc::clone(&self.sink);
         let queue = Arc::clone(&self.queue);
         let capacity = self.capacity;
-        let dropped = Arc::clone(&self.dropped);
-        let dead_lettered = Arc::clone(&self.dead_lettered);
         let token = shutdown.child_token();
 
         tokio::spawn(async move {
@@ -128,15 +127,19 @@ impl<S: EventSink + 'static> EventRecorder<S> {
             loop {
                 tokio::select! {
                     _ = token.cancelled() => {
-                        let _ = Self::flush_once(
-                            &sink,
-                            &queue,
-                            capacity,
-                            &dropped,
-                            &dead_lettered,
-                            flush_interval,
-                            true,
-                        ).await;
+                        while !queue.is_empty() {
+                            let _ = Self::flush_once(
+                                &sink,
+                                &queue,
+                                capacity,
+                                flush_interval,
+                                true,
+                            ).await;
+                            if queue.is_empty() {
+                                break;
+                            }
+                            tokio::time::sleep(flush_interval).await;
+                        }
                         break;
                     }
                     _ = interval.tick() => {
@@ -144,8 +147,6 @@ impl<S: EventSink + 'static> EventRecorder<S> {
                             &sink,
                             &queue,
                             capacity,
-                            &dropped,
-                            &dead_lettered,
                             flush_interval,
                             false,
                         ).await;
@@ -156,29 +157,23 @@ impl<S: EventSink + 'static> EventRecorder<S> {
     }
 
     fn enqueue(&self, row: EventRow) {
-        Self::enqueue_with_limit(
-            &self.queue,
-            self.capacity,
-            &self.dropped,
-            QueuedEventRow::ready(row),
-        );
+        Self::enqueue_with_limit(&self.queue, self.capacity, QueuedEventRow::ready(row));
     }
 
     fn enqueue_with_limit(
         queue: &Arc<scc::Queue<QueuedEventRow>>,
         capacity: usize,
-        dropped: &Arc<AtomicUsize>,
         row: QueuedEventRow,
     ) {
-        if queue.len() >= capacity {
-            let dropped_count = dropped.fetch_add(1, Ordering::Relaxed) + 1;
-            if dropped_count == 1 || dropped_count.is_multiple_of(100) {
-                error!(
-                    dropped = dropped_count,
-                    capacity, "Event queue is full; dropping events"
-                );
-            }
-            return;
+        let backlog = queue.len().saturating_add(1);
+        let warn_multiple = capacity.saturating_mul(10).max(1);
+        if backlog > capacity && (backlog == capacity + 1 || backlog.is_multiple_of(warn_multiple))
+        {
+            error!(
+                queued = backlog,
+                soft_capacity = capacity,
+                "Event queue backlog exceeded configured capacity; preserving events until the sink recovers"
+            );
         }
         queue.push(row);
     }
@@ -194,27 +189,14 @@ impl<S: EventSink + 'static> EventRecorder<S> {
     fn requeue_failed_rows(
         queue: &Arc<scc::Queue<QueuedEventRow>>,
         capacity: usize,
-        dropped: &Arc<AtomicUsize>,
-        dead_lettered: &Arc<AtomicUsize>,
         rows: Vec<QueuedEventRow>,
         flush_interval: Duration,
-        kind: &'static str,
     ) {
         for mut queued in rows {
             queued.retry_attempts = queued.retry_attempts.saturating_add(1);
-            if queued.retry_attempts > MAX_RETRY_ATTEMPTS {
-                let dead_lettered_count = dead_lettered.fetch_add(1, Ordering::Relaxed) + 1;
-                error!(
-                    dead_lettered = dead_lettered_count,
-                    kind,
-                    retry_attempts = queued.retry_attempts,
-                    "Dropping event after repeated flush failures"
-                );
-                continue;
-            }
             queued.next_retry_at =
                 Instant::now() + Self::retry_delay(flush_interval, queued.retry_attempts);
-            Self::enqueue_with_limit(queue, capacity, dropped, queued);
+            Self::enqueue_with_limit(queue, capacity, queued);
         }
     }
 
@@ -222,8 +204,6 @@ impl<S: EventSink + 'static> EventRecorder<S> {
         sink: &Arc<S>,
         queue: &Arc<scc::Queue<QueuedEventRow>>,
         capacity: usize,
-        dropped: &Arc<AtomicUsize>,
-        dead_lettered: &Arc<AtomicUsize>,
         flush_interval: Duration,
         force_ready: bool,
     ) -> anyhow::Result<()> {
@@ -243,7 +223,7 @@ impl<S: EventSink + 'static> EventRecorder<S> {
             }
         }
         for queued in deferred_entries {
-            Self::enqueue_with_limit(queue, capacity, dropped, queued);
+            Self::enqueue_with_limit(queue, capacity, queued);
         }
 
         if !activity_entries.is_empty() {
@@ -256,15 +236,7 @@ impl<S: EventSink + 'static> EventRecorder<S> {
                 .collect();
             if let Err(e) = sink.record_activity_events_batch(&activity_rows).await {
                 error!(error = ?e, rows = activity_rows.len(), "Failed to flush activity events");
-                Self::requeue_failed_rows(
-                    queue,
-                    capacity,
-                    dropped,
-                    dead_lettered,
-                    activity_entries,
-                    flush_interval,
-                    "activity",
-                );
+                Self::requeue_failed_rows(queue, capacity, activity_entries, flush_interval);
             }
         }
         if !worker_entries.is_empty() {
@@ -277,15 +249,7 @@ impl<S: EventSink + 'static> EventRecorder<S> {
                 .collect();
             if let Err(e) = sink.record_worker_events_batch(&worker_rows).await {
                 error!(error = ?e, rows = worker_rows.len(), "Failed to flush worker events");
-                Self::requeue_failed_rows(
-                    queue,
-                    capacity,
-                    dropped,
-                    dead_lettered,
-                    worker_entries,
-                    flush_interval,
-                    "worker",
-                );
+                Self::requeue_failed_rows(queue, capacity, worker_entries, flush_interval);
             }
         }
         Ok(())
@@ -298,11 +262,124 @@ impl<S: EventSink + 'static> EventRecorder<S> {
             &self.sink,
             &self.queue,
             self.capacity,
-            &self.dropped,
-            &self.dead_lettered,
             Duration::from_millis(1),
             true,
         )
         .await;
+    }
+}
+
+#[cfg(all(test, feature = "test-support"))]
+mod tests {
+    use super::*;
+    use anyhow::{Result, anyhow};
+    use async_trait::async_trait;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::sync::Mutex;
+
+    use crate::db::InMemoryEventSink;
+
+    async fn stopped_recorder<S: EventSink + 'static>(
+        sink: Arc<S>,
+        capacity: usize,
+    ) -> EventRecorder<S> {
+        let shutdown = CancellationToken::new();
+        shutdown.cancel();
+        let recorder = EventRecorder::new(
+            sink,
+            Arc::<str>::from("gateway-test"),
+            Duration::from_secs(60),
+            capacity,
+            shutdown,
+        );
+        tokio::task::yield_now().await;
+        recorder
+    }
+
+    #[tokio::test]
+    async fn preserves_events_beyond_soft_capacity() {
+        let sink = Arc::new(InMemoryEventSink::default());
+        let recorder = stopped_recorder(Arc::clone(&sink), 1).await;
+
+        for index in 0..3 {
+            let metadata = serde_json::json!({ "index": index });
+            recorder.record_worker_event(
+                None,
+                Some("worker-1"),
+                "task_assigned",
+                "txt3d",
+                Some("404-3dgs"),
+                None,
+                Some(&metadata),
+            );
+        }
+
+        recorder.flush_once_for_test().await;
+
+        let rows = sink.worker_rows().await;
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0].model.as_deref(), Some("404-3dgs"));
+        assert_eq!(rows[2].metadata_json["index"], serde_json::json!(2));
+    }
+
+    #[derive(Default)]
+    struct EventuallySucceedsSink {
+        attempts: AtomicUsize,
+        fail_until: usize,
+        worker: Mutex<Vec<WorkerEventRow>>,
+    }
+
+    impl EventuallySucceedsSink {
+        async fn worker_rows(&self) -> Vec<WorkerEventRow> {
+            self.worker.lock().await.clone()
+        }
+    }
+
+    #[async_trait]
+    impl EventSink for EventuallySucceedsSink {
+        async fn record_activity_events_batch(&self, _rows: &[ActivityEventRow]) -> Result<()> {
+            Ok(())
+        }
+
+        async fn record_worker_events_batch(&self, rows: &[WorkerEventRow]) -> Result<()> {
+            let attempt = self.attempts.fetch_add(1, Ordering::Relaxed) + 1;
+            if attempt <= self.fail_until {
+                return Err(anyhow!("simulated worker sink failure"));
+            }
+            self.worker.lock().await.extend(rows.iter().cloned());
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn retries_failed_batches_without_dropping_events() {
+        let sink = Arc::new(EventuallySucceedsSink {
+            fail_until: 12,
+            ..Default::default()
+        });
+        let recorder = stopped_recorder(Arc::clone(&sink), 1).await;
+        let metadata = serde_json::json!({ "worker_hotkey": "hotkey-1" });
+
+        recorder.record_worker_event(
+            None,
+            Some("worker-1"),
+            "result_success",
+            "txt3d",
+            Some("404-3dgs"),
+            None,
+            Some(&metadata),
+        );
+
+        for _ in 0..=sink.fail_until {
+            recorder.flush_once_for_test().await;
+        }
+
+        let rows = sink.worker_rows().await;
+        assert_eq!(rows.len(), 1);
+        assert!(sink.attempts.load(Ordering::Relaxed) >= sink.fail_until + 1);
+        assert_eq!(
+            rows[0].metadata_json["worker_hotkey"].as_str(),
+            Some("hotkey-1")
+        );
     }
 }

--- a/src/db/gateway_settings.rs
+++ b/src/db/gateway_settings.rs
@@ -353,4 +353,30 @@ impl GatewayRuntimeSettingsStore {
             registered_window_ms: current.registered_window_ms,
         });
     }
+
+    #[cfg(any(test, feature = "test-support"))]
+    #[allow(dead_code)]
+    pub fn seed_generic_key_limits(
+        &self,
+        generic_key: Option<Uuid>,
+        generic_global_daily_limit: u64,
+        generic_per_ip_daily_limit: u64,
+        generic_window_ms: u64,
+    ) {
+        let current = self.cached_gateway_settings();
+        self.store_gateway_settings(CachedGatewaySettings {
+            generic_key,
+            generic_global_daily_limit,
+            generic_per_ip_daily_limit,
+            generic_window_ms,
+            add_task_unauthorized_per_ip_daily_rate_limit: current
+                .add_task_unauthorized_per_ip_daily_rate_limit,
+            max_task_queue_len: current.max_task_queue_len,
+            request_file_size_limit: current.request_file_size_limit,
+            guest_generation_limit: current.guest_generation_limit,
+            guest_window_ms: current.guest_window_ms,
+            registered_generation_limit: current.registered_generation_limit,
+            registered_window_ms: current.registered_window_ms,
+        });
+    }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -8,6 +8,7 @@ mod task_lifecycle;
 use anyhow::Result;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use serde_json::Value;
 use std::sync::Arc;
 #[cfg(feature = "test-support")]
 use tokio::sync::Mutex;
@@ -42,6 +43,7 @@ pub struct Database {
 pub struct ActivityEventRow {
     pub user_id: Option<i64>,
     pub user_email: Option<String>,
+    pub account_id: Option<i64>,
     pub company_id: Option<uuid::Uuid>,
     pub company_name: Option<String>,
     pub action: String,
@@ -60,8 +62,10 @@ pub struct WorkerEventRow {
     pub worker_id: Option<String>,
     pub action: String,
     pub task_kind: String,
+    pub model: Option<String>,
     pub reason: Option<String>,
     pub gateway_name: String,
+    pub metadata_json: Value,
     pub created_at: DateTime<Utc>,
 }
 

--- a/src/db/task_lifecycle.rs
+++ b/src/db/task_lifecycle.rs
@@ -152,6 +152,9 @@ pub trait TaskLifecycleStore: Send + Sync + 'static {
         &self,
         task_id: Uuid,
     ) -> Result<Option<GenerationTaskStatusSnapshot>>;
+
+    async fn get_generation_task_generic_key_hash(&self, task_id: Uuid)
+    -> Result<Option<[u8; 16]>>;
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -214,6 +217,13 @@ impl TaskLifecycleStore for NoopTaskLifecycleStore {
         &self,
         _task_id: Uuid,
     ) -> Result<Option<GenerationTaskStatusSnapshot>> {
+        Ok(None)
+    }
+
+    async fn get_generation_task_generic_key_hash(
+        &self,
+        _task_id: Uuid,
+    ) -> Result<Option<[u8; 16]>> {
         Ok(None)
     }
 }
@@ -333,6 +343,18 @@ SELECT
   task_row.result_json->>'worker_id' AS result_worker_id
 FROM generation_tasks AS task_row
 WHERE task_row.id = $1
+LIMIT 1;
+"#;
+
+    pub(super) const Q_GENERATION_TASK_GENERIC_KEY_HASH: &'static str = r#"
+SELECT reservation_row.guest_key_hash
+FROM generation_tasks AS task_row
+INNER JOIN generation_reservations AS reservation_row
+  ON reservation_row.id = task_row.reservation_id
+WHERE task_row.id = $1
+  AND task_row.client_origin = 'guest_generic'
+  AND reservation_row.billing_mode = 'guest_free'
+  AND reservation_row.guest_key_hash IS NOT NULL
 LIMIT 1;
 "#;
 
@@ -613,6 +635,28 @@ LIMIT 1;
             result_worker_id: row.get("result_worker_id"),
         }))
     }
+
+    pub async fn get_generation_task_generic_key_hash(
+        &self,
+        task_id: Uuid,
+    ) -> Result<Option<[u8; 16]>> {
+        let params: [&(dyn ToSql + Sync); 1] = [&task_id];
+        let row = self
+            .query_prepared(StmtKey::GenerationTaskGenericKeyHash, &params)
+            .await?
+            .into_iter()
+            .next();
+
+        Ok(row.and_then(|row| {
+            let bytes: Vec<u8> = row.get("guest_key_hash");
+            if bytes.len() != 16 {
+                return None;
+            }
+            let mut hash = [0u8; 16];
+            hash.copy_from_slice(&bytes);
+            Some(hash)
+        }))
+    }
 }
 
 #[async_trait]
@@ -672,6 +716,13 @@ impl TaskLifecycleStore for Database {
         task_id: Uuid,
     ) -> Result<Option<GenerationTaskStatusSnapshot>> {
         Database::get_generation_task_status_snapshot(self, task_id).await
+    }
+
+    async fn get_generation_task_generic_key_hash(
+        &self,
+        task_id: Uuid,
+    ) -> Result<Option<[u8; 16]>> {
+        Database::get_generation_task_generic_key_hash(self, task_id).await
     }
 }
 
@@ -819,6 +870,24 @@ impl TaskLifecycleStore for TaskLifecycleStoreHandle {
             #[cfg(test)]
             TaskLifecycleStoreHandle::Shared(store) => {
                 store.get_generation_task_status_snapshot(task_id).await
+            }
+        }
+    }
+
+    async fn get_generation_task_generic_key_hash(
+        &self,
+        task_id: Uuid,
+    ) -> Result<Option<[u8; 16]>> {
+        match self {
+            TaskLifecycleStoreHandle::Database(db) => {
+                db.get_generation_task_generic_key_hash(task_id).await
+            }
+            TaskLifecycleStoreHandle::Noop(store) => {
+                store.get_generation_task_generic_key_hash(task_id).await
+            }
+            #[cfg(test)]
+            TaskLifecycleStoreHandle::Shared(store) => {
+                store.get_generation_task_generic_key_hash(task_id).await
             }
         }
     }

--- a/src/http3/handlers/common/activity.rs
+++ b/src/http3/handlers/common/activity.rs
@@ -15,6 +15,11 @@ pub struct TaskActivityContext<'a> {
 }
 
 pub fn record_task_activity(ctx: TaskActivityContext<'_>, action: &str) {
+    let account_id = ctx
+        .rate_ctx
+        .billing_owner
+        .as_ref()
+        .map(|owner| owner.account_id);
     let mut company_id = None;
     let mut company_name: Option<Arc<str>> = None;
     if ctx.rate_ctx.is_company_key
@@ -27,6 +32,7 @@ pub fn record_task_activity(ctx: TaskActivityContext<'_>, action: &str) {
     ctx.gateway_state.record_activity_event(ActivityEventRef {
         user_id: ctx.rate_ctx.user_id,
         user_email: ctx.rate_ctx.user_email.as_deref(),
+        account_id,
         company_id,
         company_name: company_name.as_deref(),
         action,

--- a/src/http3/handlers/result/add_result.rs
+++ b/src/http3/handlers/result/add_result.rs
@@ -200,6 +200,7 @@ pub async fn add_result_handler(
         }
     };
     let reason = outcome.reason.as_deref();
+    let task_model = manager.get_model(task_id).await;
 
     gateway_state.record_worker_event(WorkerEventRef {
         task_id: Some(task_id),
@@ -210,7 +211,13 @@ pub async fn add_result_handler(
             "result_failure"
         },
         task_kind: task_kind.label(),
+        model: task_model.as_deref(),
         reason,
+        metadata_json: Some(serde_json::json!({
+            "worker_hotkey": worker_hotkey_ref.as_ref(),
+            "assignment_token": assignment_token,
+            "replayed_durable_result": replayed_durable_result,
+        })),
     });
 
     let elapsed_secs = manager.get_time(task_id).await;

--- a/src/http3/handlers/result/read.rs
+++ b/src/http3/handlers/result/read.rs
@@ -198,14 +198,17 @@ pub async fn get_result_handler(
     let task_manager = gateway_state.task_manager();
     let rate_ctx = depot.require::<RateLimitContext>()?;
     authorize_task_read_access(&gateway_state, rate_ctx, get_task.id).await?;
-    let task_kind = "unknown";
+    let activity_metadata = task_manager.get_activity_metadata(get_task.id).await;
+    let (task_kind, task_model) = activity_metadata
+        .map(|metadata| (metadata.task_kind, metadata.model))
+        .unwrap_or(("unknown", None));
     record_task_activity(
         TaskActivityContext {
             gateway_state: &gateway_state,
             rate_ctx,
             origin: record_origin,
             task_kind,
-            model: None,
+            model: task_model.as_deref(),
             task_id: Some(get_task.id),
         },
         "get_result",

--- a/src/http3/handlers/task/get_tasks.rs
+++ b/src/http3/handlers/task/get_tasks.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use salvo::prelude::*;
+use serde_json::json;
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
@@ -206,7 +207,12 @@ pub async fn get_tasks_handler(
             worker_id: Some(get_tasks.worker_id.as_ref()),
             action: "task_assigned",
             task_kind: task_kind_label(&task.task),
+            model: task.task.model.as_deref(),
             reason: None,
+            metadata_json: Some(json!({
+                "worker_hotkey": get_tasks.worker_hotkey.as_ref(),
+                "assignment_token": task.assignment_token,
+            })),
         });
     }
 

--- a/src/http3/rate_limits.rs
+++ b/src/http3/rate_limits.rs
@@ -58,6 +58,13 @@ impl RateLimitReservation {
         Self { deltas, limiter }
     }
 
+    fn batch_from_mutations_with_request_id(
+        request_id: u128,
+        mutations: Vec<RateLimitMutation>,
+    ) -> Option<RateLimitMutationBatch> {
+        (!mutations.is_empty()).then(|| RateLimitMutationBatch::new(request_id, mutations))
+    }
+
     fn batch_from_mutations(mutations: Vec<RateLimitMutation>) -> Option<RateLimitMutationBatch> {
         RateLimitMutationBatch::with_generated_request_id(mutations)
     }
@@ -121,12 +128,23 @@ impl RateLimitReservation {
         Self::batch_from_mutations(self.refund_mutations())
     }
 
+    pub fn refund_batch_with_request_id(&self, request_id: u128) -> Option<RateLimitMutationBatch> {
+        Self::batch_from_mutations_with_request_id(request_id, self.refund_mutations())
+    }
+
     pub fn success_mutations(&self) -> Vec<RateLimitMutation> {
         self.active_release_mutations()
     }
 
     pub fn success_batch(&self) -> Option<RateLimitMutationBatch> {
         Self::batch_from_mutations(self.success_mutations())
+    }
+
+    pub fn success_batch_with_request_id(
+        &self,
+        request_id: u128,
+    ) -> Option<RateLimitMutationBatch> {
+        Self::batch_from_mutations_with_request_id(request_id, self.success_mutations())
     }
 
     pub fn active_release_mutations(&self) -> Vec<RateLimitMutation> {
@@ -269,6 +287,8 @@ impl Default for UnauthorizedDailyLimiter {
 fn user_subject_id(user_id: i64) -> u128 {
     u128::from(user_id.max(0) as u64)
 }
+
+const GENERIC_GLOBAL_SUBJECT_ID: u128 = 0;
 
 impl RateLimitContext {
     pub fn has_authorized_key(&self) -> bool {
@@ -664,6 +684,15 @@ pub async fn reserve_add_task_rate_limit(
             daily_limit,
             scope_label: "User",
             require_day_match: daily_limit > 0,
+        });
+    } else if ctx.key_is_uuid && ctx.is_generic_key {
+        subjects.push(SubjectParams {
+            subject: Subject::GenericGlobal,
+            id: GENERIC_GLOBAL_SUBJECT_ID,
+            active_limit: cfg.http().generic_key_concurrent_limit as u64,
+            daily_limit: 0,
+            scope_label: "Generic key",
+            require_day_match: false,
         });
     }
 

--- a/src/raft/gateway_state.rs
+++ b/src/raft/gateway_state.rs
@@ -31,6 +31,7 @@ use uuid::Uuid;
 pub struct ActivityEventRef<'a> {
     pub user_id: Option<i64>,
     pub user_email: Option<&'a str>,
+    pub account_id: Option<i64>,
     pub company_id: Option<Uuid>,
     pub company_name: Option<&'a str>,
     pub action: &'a str,
@@ -45,7 +46,9 @@ pub struct WorkerEventRef<'a> {
     pub worker_id: Option<&'a str>,
     pub action: &'a str,
     pub task_kind: &'a str,
+    pub model: Option<&'a str>,
     pub reason: Option<&'a str>,
+    pub metadata_json: Option<serde_json::Value>,
 }
 
 #[derive(Serialize)]
@@ -701,6 +704,16 @@ where
             .await
     }
 
+    pub async fn get_generation_task_generic_key_hash(
+        &self,
+        task_id: Uuid,
+    ) -> Result<Option<[u8; 16]>> {
+        self.internal
+            .task_lifecycle_store
+            .get_generation_task_generic_key_hash(task_id)
+            .await
+    }
+
     pub fn cluster_name_matches(&self, cluster_name: &str) -> bool {
         self.internal
             .config
@@ -720,6 +733,7 @@ where
         self.internal.event_recorder.record_activity(
             event.user_id,
             event.user_email,
+            event.account_id,
             event.company_id,
             event.company_name,
             event.action,
@@ -736,7 +750,9 @@ where
             event.worker_id,
             event.action,
             event.task_kind,
+            event.model,
             event.reason,
+            event.metadata_json.as_ref(),
         );
     }
 

--- a/src/raft/mod.rs
+++ b/src/raft/mod.rs
@@ -32,9 +32,10 @@ use crate::http3::server::Http3Server;
 use crate::metrics::Metrics;
 use crate::raft::client::RClient;
 use crate::raft::client::RClientBuilder;
-use crate::raft::store::RateLimitMutationBatch;
 use crate::raft::store::Request;
 use crate::raft::store::Response;
+use crate::raft::store::{RateLimitMutation, RateLimitMutationBatch, Subject};
+use crate::task::rate_limit_completion_request_id;
 use crate::task::{TaskManager, TaskManagerInit};
 use anyhow::Result;
 use anyhow::bail;
@@ -76,6 +77,24 @@ pub type StateMachineStore = store::StateMachineStore;
 pub type Raft = openraft::Raft<TypeConfig>;
 
 pub(crate) const SNAPSHOT_COMPRESSION_LVL: i32 = 1;
+const GENERIC_GLOBAL_SUBJECT_ID: u128 = 0;
+
+fn generic_task_recovery_rate_limit_batch(
+    task_id: uuid::Uuid,
+    _guest_key_hash: [u8; 16],
+) -> RateLimitMutationBatch {
+    let day_epoch = crate::raft::rate_limit::DistributedRateLimiter::current_day_epoch();
+    RateLimitMutationBatch::new(
+        rate_limit_completion_request_id(task_id),
+        vec![RateLimitMutation {
+            subject: Subject::GenericGlobal,
+            id: GENERIC_GLOBAL_SUBJECT_ID,
+            day_epoch,
+            active_delta: -1,
+            day_delta: 0,
+        }],
+    )
+}
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum GatewayMode {
@@ -374,6 +393,37 @@ impl Gateway {
             {
                 Ok(expired_task_ids) => {
                     if !expired_task_ids.is_empty() {
+                        for task_id in &expired_task_ids {
+                            match gateway_state
+                                .get_generation_task_generic_key_hash(*task_id)
+                                .await
+                            {
+                                Ok(Some(guest_key_hash)) => {
+                                    let batch = generic_task_recovery_rate_limit_batch(
+                                        *task_id,
+                                        guest_key_hash,
+                                    );
+                                    if let Err(err) = gateway_state
+                                        .submit_rate_limit_mutation_batch(&batch, None)
+                                        .await
+                                    {
+                                        error!(
+                                            task_id = %task_id,
+                                            error = ?err,
+                                            "Failed to reconcile generic concurrent rate limit after task timeout"
+                                        );
+                                    }
+                                }
+                                Ok(None) => {}
+                                Err(err) => {
+                                    error!(
+                                        task_id = %task_id,
+                                        error = ?err,
+                                        "Failed to load generic rate limit key for expired task"
+                                    );
+                                }
+                            }
+                        }
                         info!(
                             "Expired {} overdue generation tasks in the billing database",
                             expired_task_ids.len()

--- a/src/raft/test_utils.rs
+++ b/src/raft/test_utils.rs
@@ -1,12 +1,13 @@
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Once};
+use std::sync::{Arc, Once, OnceLock};
 use std::time::Instant;
 use std::{io::ErrorKind, time::Duration as StdDuration};
 
 use anyhow::{Result, bail};
 use foldhash::fast::RandomState;
 use openraft::{BasicNode, LogId};
+use tokio::sync::Mutex;
 use tokio::time::Duration;
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
@@ -19,6 +20,7 @@ use crate::raft::{LogStore, Network, NodeId, Raft, StateMachineStore, TypeConfig
 static COUNTER: AtomicU64 = AtomicU64::new(0);
 static TRACING: Once = Once::new();
 static CRYPTO_PROVIDER_INIT: Once = Once::new();
+static NETWORK_BIND_LOCK: OnceLock<Arc<Mutex<()>>> = OnceLock::new();
 
 pub(crate) fn unique_path(dir: &Path, prefix: &str, suffix: &str) -> PathBuf {
     let id = COUNTER.fetch_add(1, Ordering::Relaxed);
@@ -38,6 +40,12 @@ pub(crate) fn ensure_crypto_provider_for_tests() {
     CRYPTO_PROVIDER_INIT.call_once(|| {
         crate::raft::init_crypto_provider().expect("crypto provider init must succeed");
     });
+}
+
+pub(crate) fn network_bind_lock() -> Arc<Mutex<()>> {
+    NETWORK_BIND_LOCK
+        .get_or_init(|| Arc::new(Mutex::new(())))
+        .clone()
 }
 
 pub(crate) fn membership_from(

--- a/src/raft/tests/cluster_bootstrap.rs
+++ b/src/raft/tests/cluster_bootstrap.rs
@@ -7,7 +7,7 @@ use openraft::Membership;
 async fn test_three_node_cluster() -> Result<()> {
     init_tracing();
 
-    let node_configs = reserve_node_configs(3)?;
+    let (_network_guard, node_configs) = reserve_node_configs(3).await?;
     let node_clients = make_node_clients(node_configs.len());
 
     let (_config, _pcfg, raft_nodes, state_machines, _server_handles) =
@@ -60,7 +60,7 @@ async fn test_three_node_cluster() -> Result<()> {
 async fn test_vote_mode_all_initialized() -> Result<()> {
     init_tracing();
 
-    let node_configs = reserve_node_configs(3)?;
+    let (_network_guard, node_configs) = reserve_node_configs(3).await?;
     let node_clients = make_node_clients(node_configs.len());
 
     let (_config, _pcfg, raft_nodes, state_machines, _server_handles) =

--- a/src/raft/tests/cross_gateway_add_task.rs
+++ b/src/raft/tests/cross_gateway_add_task.rs
@@ -39,6 +39,7 @@ use uuid::Uuid;
 const LOCALHOST: &str = "127.0.0.1";
 const TEST_DOMAIN: &str = "localhost";
 const PROMPT_JSON: &str = r#"{"prompt":"mechanic robot"}"#;
+const GENERIC_WINDOW_MS: u64 = 86_400_000;
 
 #[derive(Default)]
 struct BlockingCreateStore {
@@ -125,6 +126,13 @@ impl TaskLifecycleStore for BlockingCreateStore {
         &self,
         _task_id: Uuid,
     ) -> Result<Option<GenerationTaskStatusSnapshot>> {
+        Ok(None)
+    }
+
+    async fn get_generation_task_generic_key_hash(
+        &self,
+        _task_id: Uuid,
+    ) -> Result<Option<[u8; 16]>> {
         Ok(None)
     }
 }
@@ -339,12 +347,17 @@ async fn build_gateway_node(
     })
 }
 
-async fn setup_cross_gateway_harness() -> Result<CrossGatewayHarness> {
+async fn setup_cross_gateway_harness(
+    generic_key_concurrent_limit: Option<usize>,
+) -> Result<CrossGatewayHarness> {
     init_tracing();
     ensure_crypto_provider();
 
-    let base_config = load_base_config();
-    let node_configs = reserve_node_configs(3)?;
+    let mut base_config = load_base_config();
+    if let Some(limit) = generic_key_concurrent_limit {
+        base_config.http.generic_key_concurrent_limit = limit;
+    }
+    let (_network_guard, node_configs) = reserve_node_configs(3).await?;
     let node_clients = make_node_clients(node_configs.len());
     let (_config, _pcfg, raft_nodes, state_machines, raft_servers) =
         setup_connected_cluster(&node_configs, node_clients, None).await?;
@@ -452,6 +465,7 @@ async fn assert_cross_gateway_limit_rejection(
     api_key: &str,
     subject: Subject,
     subject_id: u128,
+    expected_message: Option<&str>,
 ) -> Result<()> {
     let (_leader_id, leader_index) = wait_for_consistent_leader_index(
         &harness.raft_nodes,
@@ -507,6 +521,12 @@ async fn assert_cross_gateway_limit_rejection(
         payload.get("error").and_then(|value| value.as_str()),
         Some("concurrent_limit")
     );
+    if let Some(expected_message) = expected_message {
+        assert_eq!(
+            payload.get("message").and_then(|value| value.as_str()),
+            Some(expected_message)
+        );
+    }
     assert_eq!(
         harness.blocking_store.create_calls(),
         1,
@@ -524,7 +544,7 @@ async fn assert_cross_gateway_limit_rejection(
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 6)]
 async fn second_gateway_rejects_same_user_before_create_generation_task() -> Result<()> {
-    let harness = setup_cross_gateway_harness().await?;
+    let harness = setup_cross_gateway_harness(None).await?;
     let api_key = Uuid::new_v4().to_string();
     let user_id = 42i64;
     for node in &harness.nodes {
@@ -538,13 +558,14 @@ async fn second_gateway_rejects_same_user_before_create_generation_task() -> Res
         &api_key,
         Subject::User,
         u128::from(user_id as u64),
+        Some("User concurrent task limit exceeded."),
     )
     .await
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 6)]
 async fn second_gateway_rejects_same_company_before_create_generation_task() -> Result<()> {
-    let harness = setup_cross_gateway_harness().await?;
+    let harness = setup_cross_gateway_harness(None).await?;
     let api_key = Uuid::new_v4().to_string();
     let company_id = Uuid::new_v4();
     for node in &harness.nodes {
@@ -553,6 +574,36 @@ async fn second_gateway_rejects_same_company_before_create_generation_task() -> 
             .await;
     }
 
-    assert_cross_gateway_limit_rejection(&harness, &api_key, Subject::Company, company_id.as_u128())
-        .await
+    assert_cross_gateway_limit_rejection(
+        &harness,
+        &api_key,
+        Subject::Company,
+        company_id.as_u128(),
+        Some("Acme concurrent task limit exceeded."),
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 6)]
+async fn second_gateway_rejects_same_generic_key_before_create_generation_task() -> Result<()> {
+    let harness = setup_cross_gateway_harness(Some(1)).await?;
+    let generic_key = harness.nodes[0]
+        .key_validator
+        .generic_key()
+        .expect("generic key");
+    let api_key = generic_key.to_string();
+    for node in &harness.nodes {
+        node.key_validator
+            .gateway_settings()
+            .seed_generic_key_limits(Some(generic_key), 10, 10, GENERIC_WINDOW_MS);
+    }
+
+    assert_cross_gateway_limit_rejection(
+        &harness,
+        &api_key,
+        Subject::GenericGlobal,
+        0,
+        Some("Generic key concurrent task limit exceeded."),
+    )
+    .await
 }

--- a/src/raft/tests/leader_failover.rs
+++ b/src/raft/tests/leader_failover.rs
@@ -4,7 +4,7 @@ use super::*;
 async fn test_leader_failover() -> anyhow::Result<()> {
     init_tracing();
 
-    let node_configs = reserve_node_configs(5)?;
+    let (_network_guard, node_configs) = reserve_node_configs(5).await?;
     let node_clients = make_node_clients(node_configs.len());
 
     let (_config, _pcfg, mut raft_nodes, mut state_machines, mut server_handles) =

--- a/src/raft/tests/membership_flows.rs
+++ b/src/raft/tests/membership_flows.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeSet;
 async fn test_add_node_to_three_node_cluster() -> Result<()> {
     init_tracing();
 
-    let node_configs = reserve_node_configs(4)?;
+    let (_network_guard, node_configs) = reserve_node_configs(4).await?;
     let initial_configs = node_configs[..3].to_vec();
     let new_node_id = node_configs[3].0;
     let new_node_addr = node_configs[3].1.as_str();
@@ -77,7 +77,7 @@ async fn test_add_node_to_three_node_cluster() -> Result<()> {
 async fn test_add_voter_node_to_three_node_cluster_change_membership() -> Result<()> {
     init_tracing();
 
-    let node_configs = reserve_node_configs(4)?;
+    let (_network_guard, node_configs) = reserve_node_configs(4).await?;
     let initial_configs = node_configs[..3].to_vec();
     let new_node_id = node_configs[3].0;
     let new_node_addr = node_configs[3].1.as_str();

--- a/src/raft/tests/mod.rs
+++ b/src/raft/tests/mod.rs
@@ -7,7 +7,7 @@ use crate::raft::StateMachineStore;
 use crate::raft::client::RClientBuilder;
 use crate::raft::test_utils::{
     ensure_crypto_provider_for_tests, init_tracing, make_node_clients, membership_from,
-    reserve_udp_addresses, start_test_rserver, unique_path, wait_for_log_commit,
+    network_bind_lock, reserve_udp_addresses, start_test_rserver, unique_path, wait_for_log_commit,
     wait_for_node_to_be_voter, wait_for_snapshot_file,
 };
 use crate::{
@@ -177,15 +177,21 @@ mod cluster_setup {
 
     pub(super) type OwnedNodeConfig = (u64, String);
 
-    pub(super) fn reserve_node_configs(node_count: usize) -> Result<Vec<OwnedNodeConfig>> {
+    pub(super) async fn reserve_node_configs(
+        node_count: usize,
+    ) -> Result<(tokio::sync::OwnedMutexGuard<()>, Vec<OwnedNodeConfig>)> {
+        let network_guard = network_bind_lock().lock_owned().await;
         let (node_addrs, node_addr_reservations) = reserve_udp_addresses(node_count)?;
         drop(node_addr_reservations);
 
-        Ok(node_addrs
-            .into_iter()
-            .enumerate()
-            .map(|(idx, addr)| (idx as u64 + 1, addr))
-            .collect())
+        Ok((
+            network_guard,
+            node_addrs
+                .into_iter()
+                .enumerate()
+                .map(|(idx, addr)| (idx as u64 + 1, addr))
+                .collect(),
+        ))
     }
 
     pub(super) fn node_config_refs(node_configs: &[OwnedNodeConfig]) -> Vec<(u64, &str)> {

--- a/src/raft/tests/rate_limit_sync.rs
+++ b/src/raft/tests/rate_limit_sync.rs
@@ -15,7 +15,7 @@ struct RateLimitSyncCluster {
 }
 
 async fn setup_rate_limit_sync_cluster() -> Result<RateLimitSyncCluster> {
-    let node_configs = reserve_node_configs(3)?;
+    let (_network_guard, node_configs) = reserve_node_configs(3).await?;
     let node_clients = make_node_clients(node_configs.len());
     let (_config, _pcfg, raft_nodes, state_machines, server_handles) =
         setup_connected_cluster(&node_configs, node_clients, None).await?;

--- a/src/raft/tests/snapshot_flows.rs
+++ b/src/raft/tests/snapshot_flows.rs
@@ -7,7 +7,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 async fn test_node_restart_from_snapshot_retains_voter() -> anyhow::Result<()> {
     init_tracing();
 
-    let node_configs = reserve_node_configs(3)?;
+    let (_network_guard, node_configs) = reserve_node_configs(3).await?;
 
     let storage_paths: Vec<NodeStoragePaths> = node_configs
         .iter()
@@ -109,7 +109,7 @@ async fn test_add_voter_node_after_snapshot_compaction() -> Result<()> {
 
     // Set up an initial three-node cluster with persistent storage so snapshots
     // produce on-disk artifacts and purge earlier log entries.
-    let node_configs = reserve_node_configs(4)?;
+    let (_network_guard, node_configs) = reserve_node_configs(4).await?;
     let initial_configs = node_configs[..3].to_vec();
     let new_node_id = node_configs[3].0;
     let new_node_addr = node_configs[3].1.as_str();

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -4,6 +4,7 @@ use foldhash::HashSet;
 use foldhash::fast::RandomState;
 use scc::{HashMap, hash_map::Entry};
 use serde::Serialize;
+use serde_json::json;
 use std::cmp::Reverse;
 use std::collections::BinaryHeap;
 use std::fmt;
@@ -19,10 +20,15 @@ use crate::common::rate_limit_buffer::RateLimitMutationBuffer;
 use crate::crypto::hotkey::Hotkey;
 use crate::db::EventRecorder;
 use crate::http3::rate_limits::RateLimitReservation;
-use crate::metrics::{Metrics, TaskInProgressGuard};
+use crate::metrics::{Metrics, TaskInProgressGuard, TaskKind};
 
 const TASK_TIMED_OUT_REASON: &str = "Task timed out";
 const PENDING_RESULT_COMMIT_GRACE: Duration = Duration::from_secs(5);
+const RATE_LIMIT_COMPLETION_REQUEST_ID_XOR: u128 = 0x7b2f_4d91_a6c3_e805_19fe_42ac_55d0_3b71;
+
+pub(crate) fn rate_limit_completion_request_id(task_id: Uuid) -> u128 {
+    task_id.as_u128() ^ RATE_LIMIT_COMPLETION_REQUEST_ID_XOR
+}
 
 struct TaskManagerInnerInit {
     initial_capacity: usize,
@@ -59,6 +65,7 @@ struct TaskState {
     task_expires_at: Option<Instant>,
     last_result_instant: Option<Instant>,
     results_expires_at: Option<Instant>,
+    task_kind: TaskKind,
     prompt: Option<Arc<String>>,
     image: Option<Bytes>,
     model: Option<String>,
@@ -74,6 +81,14 @@ struct TaskState {
     seed: Option<i32>,
     finished_results_count: usize,
     rate_limit_reservation: Option<RateLimitReservation>,
+}
+
+fn task_kind_from_task(task: &crate::api::Task) -> TaskKind {
+    if task.image.is_some() {
+        TaskKind::ImageTo3D
+    } else {
+        TaskKind::TextTo3D
+    }
 }
 
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -134,6 +149,7 @@ impl TaskState {
             task_expires_at: Some(now + result_lifetime),
             last_result_instant: None,
             results_expires_at: None,
+            task_kind: task_kind_from_task(task),
             prompt: task.prompt.as_ref().map(Arc::clone),
             image: task.image.clone(),
             model: task.model.clone(),
@@ -174,6 +190,11 @@ pub enum TaskStatus {
 
 pub struct TaskResultBundle {
     pub results: Vec<AddTaskResultRequest>,
+    pub model: Option<String>,
+}
+
+pub struct TaskActivityMetadata {
+    pub task_kind: &'static str,
     pub model: Option<String>,
 }
 
@@ -372,6 +393,7 @@ impl TaskManager {
                                         let mut schedule_results_expiration = None;
                                         let mut timed_out_workers = Vec::new();
                                         let mut timed_out_task_kind = None;
+                                        let mut timed_out_model = None;
                                         let mut timed_out_elapsed_secs = None;
                                         match inner.tasks.entry_async(task_id).await {
                                             Entry::Occupied(mut entry) => {
@@ -410,13 +432,7 @@ impl TaskManager {
                                                         )));
                                                         continue;
                                                     }
-                                                    let task_kind = if state.image.is_some() {
-                                                        "img3d"
-                                                    } else if state.prompt.is_some() {
-                                                        "txt3d"
-                                                    } else {
-                                                        "unknown"
-                                                    };
+                                                    let task_kind = state.task_kind.label();
                                                     let assigned_workers = std::mem::take(&mut state.assigned_workers);
                                                     let mut assigned_worker_ids =
                                                         std::mem::take(&mut state.assigned_worker_ids);
@@ -426,6 +442,7 @@ impl TaskManager {
                                                         timed_out_workers.push((worker, worker_id));
                                                     }
                                                     timed_out_task_kind = Some(task_kind);
+                                                    timed_out_model = state.model.clone();
                                                     timed_out_elapsed_secs = state
                                                         .execution_start
                                                         .map(|start| start.elapsed().as_secs_f64());
@@ -512,12 +529,17 @@ impl TaskManager {
                                             for (worker, worker_id) in timed_out_workers {
                                                 inner.metrics.inc_timeout_failed(worker.as_ref()).await;
                                                 if let Some(recorder) = inner.worker_event_recorder.as_ref() {
+                                                    let metadata = json!({
+                                                        "worker_hotkey": worker.as_ref(),
+                                                    });
                                                     recorder.record_worker_event(
                                                         Some(task_id),
                                                         worker_id.as_deref(),
                                                         "timeout",
                                                         task_kind,
+                                                        timed_out_model.as_deref(),
                                                         None,
+                                                        Some(&metadata),
                                                     );
                                                 }
                                             }
@@ -526,7 +548,7 @@ impl TaskManager {
                                             inner.schedule_results_expiration(task_id, when);
                                         }
                                         if let Some((reservation, success)) = completed_reservation {
-                                            Self::emit_completion(inner.as_ref(), reservation, success)
+                                            Self::emit_completion(inner.as_ref(), task_id, reservation, success)
                                                 .await;
                                         }
                                     }
@@ -577,7 +599,7 @@ impl TaskManager {
             }
         };
         if let Some((reservation, success)) = completed_reservation {
-            Self::emit_completion(self.inner.as_ref(), reservation, success).await;
+            Self::emit_completion(self.inner.as_ref(), task_id, reservation, success).await;
         }
         if let Some(when) = results_expires_at {
             self.inner.schedule_results_expiration(task_id, when);
@@ -646,7 +668,7 @@ impl TaskManager {
                 Entry::Vacant(_) => return Err(AddResultError::NotAssigned),
             };
         if let Some((reservation, success)) = completed_reservation {
-            Self::emit_completion(self.inner.as_ref(), reservation, success).await;
+            Self::emit_completion(self.inner.as_ref(), task_id, reservation, success).await;
         }
         if let Some(when) = results_expires_at {
             self.inner.schedule_results_expiration(task_id, when);
@@ -722,6 +744,7 @@ impl TaskManager {
         match self.inner.tasks.entry_async(task.id).await {
             Entry::Occupied(mut entry) => {
                 let state = entry.get_mut();
+                state.task_kind = task_kind_from_task(task);
                 state.prompt = task.prompt.as_ref().map(Arc::clone);
                 state.image = task.image.clone();
                 state.model = task.model.clone();
@@ -752,30 +775,42 @@ impl TaskManager {
 
     async fn emit_completion(
         inner: &TaskManagerInner,
+        task_id: Uuid,
         reservation: RateLimitReservation,
         success: bool,
     ) {
+        let request_id = rate_limit_completion_request_id(task_id);
         if success {
             reservation.rollback_pending_success().await;
-            if let Some(batch) = reservation.success_batch() {
+            if let Some(batch) = reservation.success_batch_with_request_id(request_id) {
                 inner.rate_limit_mutation_queue.push(batch).await;
             }
             return;
         }
 
         reservation.rollback_pending().await;
-        if let Some(batch) = reservation.refund_batch() {
+        if let Some(batch) = reservation.refund_batch_with_request_id(request_id) {
             inner.rate_limit_mutation_queue.push(batch).await;
         }
     }
 
-    #[cfg(test)]
     pub async fn get_model(&self, task_id: Uuid) -> Option<String> {
         self.inner
             .tasks
             .get_async(&task_id)
             .await
             .and_then(|entry| entry.model.clone())
+    }
+
+    pub async fn get_activity_metadata(&self, task_id: Uuid) -> Option<TaskActivityMetadata> {
+        self.inner
+            .tasks
+            .get_async(&task_id)
+            .await
+            .map(|entry| TaskActivityMetadata {
+                task_kind: entry.task_kind.label(),
+                model: entry.model.clone(),
+            })
     }
 
     pub async fn record_assignment(&self, task_id: Uuid, worker: Hotkey, worker_id: Arc<str>) {

--- a/src/task/tests.rs
+++ b/src/task/tests.rs
@@ -801,6 +801,12 @@ async fn model_persists_until_result_retrieval() {
         task_manager.get_model(task_id).await.as_deref(),
         Some("404-3dgs")
     );
+    let activity_metadata = task_manager
+        .get_activity_metadata(task_id)
+        .await
+        .expect("activity metadata should exist");
+    assert_eq!(activity_metadata.task_kind, "txt3d");
+    assert_eq!(activity_metadata.model.as_deref(), Some("404-3dgs"));
 
     let results_bundle = task_manager
         .get_result(task_id)

--- a/tests/client_http_api/add_task.rs
+++ b/tests/client_http_api/add_task.rs
@@ -1,3 +1,4 @@
+use std::net::{IpAddr, Ipv4Addr};
 use std::time::Duration;
 
 use std::sync::Arc;
@@ -244,11 +245,17 @@ async fn add_task_accepts_valid_model_params_json() {
 async fn add_task_origin_header_success() {
     let h = build_harness().await;
     set_guest_free_settings(&h, 2, 86_400_000).await;
+    let service_a = h
+        .service
+        .with_local_address(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)));
+    let service_b = h
+        .service
+        .with_local_address(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 3)));
     let res = TestClient::post("http://localhost/add_task")
         .add_header("x-api-key", h.api_key.to_string(), true)
         .add_header("x-client-origin", "discord", true)
         .json(&serde_json::json!({"prompt": "robot"}))
-        .send(&h.service)
+        .send(&service_a)
         .await;
     let (status, _headers, body) = read_response(res).await;
     assert_eq!(
@@ -262,7 +269,7 @@ async fn add_task_origin_header_success() {
         .add_header("x-api-key", h.api_key.to_string(), true)
         .add_header("x-client-origin", "unknown-tool", true)
         .json(&serde_json::json!({"prompt": "robot"}))
-        .send(&h.service)
+        .send(&service_b)
         .await;
     let (status, _headers, body) = read_response(res).await;
     assert_eq!(
@@ -982,8 +989,12 @@ async fn add_task_generic_key_ignores_site_guest_limits() {
 }
 
 #[tokio::test]
-async fn add_task_generic_key_respects_sql_generic_policies() {
-    let h = build_harness().await;
+async fn add_task_generic_key_hits_concurrent_gate_before_sql_generic_policies() {
+    let h = build_harness_with_options(GatewayHarnessOptions {
+        generic_key_concurrent_limit: Some(1),
+        ..GatewayHarnessOptions::default()
+    })
+    .await;
     set_generic_rate_limit_policies(
         &h,
         RateLimitPolicies {
@@ -1010,10 +1021,10 @@ async fn add_task_generic_key_respects_sql_generic_policies() {
     assert_eq!(second_status, StatusCode::TOO_MANY_REQUESTS);
     let payload: serde_json::Value =
         serde_json::from_slice(&second_body).expect("rate limit body should be valid json");
-    assert_eq!(payload["error"], "daily_limit");
+    assert_eq!(payload["error"], "concurrent_limit");
     assert_eq!(
         payload["message"],
-        "Generic key global rolling limit exceeded."
+        "Generic key concurrent task limit exceeded."
     );
 }
 
@@ -1100,7 +1111,7 @@ async fn lowered_queue_cap_only_blocks_new_admissions() {
 }
 
 #[tokio::test]
-async fn add_task_bad_request_does_not_consume_guest_quota() {
+async fn add_task_bad_request_does_not_consume_generic_quota() {
     let h = build_harness().await;
     set_generic_rate_limit_policies(
         &h,
@@ -1120,35 +1131,8 @@ async fn add_task_bad_request_does_not_consume_guest_quota() {
     let (bad_status, _headers, _body) = read_response(bad).await;
     assert_eq!(bad_status, StatusCode::BAD_REQUEST);
 
-    // First valid request should still pass (bad payload did not consume the SQL generic quota).
-    let first_valid = TestClient::post("http://localhost/add_task")
-        .add_header("x-api-key", h.api_key.to_string(), true)
-        .json(&serde_json::json!({"prompt": "robot"}))
-        .send(&h.service)
-        .await;
-    let (first_status, _headers, first_body) = read_response(first_valid).await;
-    assert_eq!(
-        first_status,
-        StatusCode::OK,
-        "first valid request failed: {}",
-        String::from_utf8_lossy(&first_body)
-    );
-
-    // Second valid request should now be rejected by the SQL generic rolling window.
-    let second_valid = TestClient::post("http://localhost/add_task")
-        .add_header("x-api-key", h.api_key.to_string(), true)
-        .json(&serde_json::json!({"prompt": "robot"}))
-        .send(&h.service)
-        .await;
-    let (next_status, _headers, next_body) = read_response(second_valid).await;
-    assert_eq!(next_status, StatusCode::TOO_MANY_REQUESTS);
-    let payload: serde_json::Value =
-        serde_json::from_slice(&next_body).expect("guest limit body should be valid json");
-    assert_eq!(payload["error"], "daily_limit");
-    assert_eq!(
-        payload["message"],
-        "Generic key global rolling limit exceeded."
-    );
+    // A valid request should still pass, proving the bad payload did not consume generic quota.
+    let _task_id = add_task_prompt(&h, "robot", None).await;
 }
 
 #[tokio::test]

--- a/tests/client_http_api/generic_rate_limits.rs
+++ b/tests/client_http_api/generic_rate_limits.rs
@@ -1,0 +1,366 @@
+use std::net::{IpAddr, Ipv4Addr};
+use std::time::Duration;
+
+use http::StatusCode;
+use serde_json::Value;
+use tokio::time::{Instant, sleep};
+use uuid::Uuid;
+
+use gateway::crypto::crypto_provider::GuestIpHasher;
+
+use crate::common::{
+    GatewayHarnessOptions, GatewayRuntimeHarness, TestClient, TestService, read_response,
+};
+
+fn loopback_ip(last_octet: u8) -> IpAddr {
+    IpAddr::V4(Ipv4Addr::new(127, 0, 0, last_octet))
+}
+
+fn service_for_ip(harness: &GatewayRuntimeHarness, last_octet: u8) -> TestService {
+    harness.service.with_local_address(loopback_ip(last_octet))
+}
+
+async fn post_add_task(service: &TestService, api_key: &str, prompt: &str) -> (StatusCode, Value) {
+    let response = TestClient::post("http://localhost/add_task")
+        .add_header("x-api-key", api_key, true)
+        .json(&serde_json::json!({ "prompt": prompt }))
+        .send(service)
+        .await;
+    let (status, _headers, body) = read_response(response).await;
+    let payload: Value = serde_json::from_slice(&body).unwrap_or_else(|err| {
+        panic!(
+            "json response parse failed with status {}: {} ({err})",
+            status,
+            String::from_utf8_lossy(&body),
+        )
+    });
+    (status, payload)
+}
+
+async fn create_generic_task(service: &TestService, api_key: &str, prompt: &str) -> Uuid {
+    let (status, payload) = post_add_task(service, api_key, prompt).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "generic add_task failed: {payload:?}"
+    );
+    let task_id = payload.get("id").and_then(Value::as_str).expect("task id");
+    Uuid::parse_str(task_id).expect("uuid task id")
+}
+
+async fn wait_for_generic_success(
+    service: &TestService,
+    api_key: &str,
+    prompt: &str,
+    timeout: Duration,
+) -> Uuid {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let (status, payload) = post_add_task(service, api_key, prompt).await;
+        if status == StatusCode::OK {
+            let task_id = payload.get("id").and_then(Value::as_str).expect("task id");
+            return Uuid::parse_str(task_id).expect("uuid task id");
+        }
+        assert_eq!(
+            status,
+            StatusCode::TOO_MANY_REQUESTS,
+            "unexpected retry status while waiting for generic slot release: {payload:?}"
+        );
+        if Instant::now() >= deadline {
+            panic!("generic request did not unblock before timeout: {payload:?}");
+        }
+        sleep(Duration::from_millis(500)).await;
+    }
+}
+
+async fn set_generic_rate_limit_settings(
+    harness: &GatewayRuntimeHarness,
+    generic_key: Uuid,
+    global_limit: i32,
+    per_ip_limit: i32,
+    window_ms: i64,
+) {
+    let updated = harness
+        .db_client
+        .execute(
+            "UPDATE app_settings
+             SET gateway_generic_key = $1,
+                 gateway_generic_global_daily_limit = $2,
+                 gateway_generic_per_ip_daily_limit = $3,
+                 gateway_generic_window_ms = $4,
+                 updated_at = FLOOR(EXTRACT(EPOCH FROM clock_timestamp()) * 1000)::BIGINT
+             WHERE id = 1",
+            &[&generic_key, &global_limit, &per_ip_limit, &window_ms],
+        )
+        .await
+        .expect("update generic rate limit settings");
+    assert_eq!(updated, 1, "expected exactly one app_settings row");
+    harness
+        .gateway
+        .sync_db_caches_for_test()
+        .await
+        .expect("sync db caches");
+}
+
+#[derive(Debug)]
+struct GenericSubmitResult {
+    ok: bool,
+    error_code: Option<String>,
+    error_message: Option<String>,
+}
+
+fn current_time_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock")
+        .as_millis() as i64
+}
+
+fn generic_key_hash(secret: &str, subject: &str) -> Vec<u8> {
+    GuestIpHasher::new(secret)
+        .expect("guest ip hasher")
+        .compute_hash_128(subject)
+        .to_vec()
+}
+
+async fn submit_generic_task_with_now(
+    harness: &GatewayRuntimeHarness,
+    now_ms: i64,
+    global_limit: i32,
+    per_ip_limit: i32,
+    window_ms: i64,
+    key_hash: &[u8],
+) -> GenericSubmitResult {
+    let deadline_at_ms = now_ms + 60_000;
+    let row = harness
+        .db_client
+        .query_one(
+            "SELECT ok, error_code, error_message
+             FROM generation_submit_task(
+               $1,
+               NULL,
+               NULL,
+               NULL,
+               NULL,
+               'text_to_3d',
+               '404-3dgs',
+               1,
+               $2,
+               'test-node',
+               'guest_generic',
+               '{}'::jsonb,
+               NULL,
+               NULL,
+               $3,
+               NULL,
+               NULL,
+               NULL,
+               'generic_key',
+               $4,
+               $5,
+               $6,
+               $7
+             )",
+            &[
+                &Uuid::new_v4(),
+                &deadline_at_ms,
+                &now_ms,
+                &global_limit,
+                &per_ip_limit,
+                &window_ms,
+                &&key_hash[..],
+            ],
+        )
+        .await
+        .expect("submit generic guest task");
+    GenericSubmitResult {
+        ok: row.get("ok"),
+        error_code: row.get("error_code"),
+        error_message: row.get("error_message"),
+    }
+}
+
+#[tokio::test]
+async fn generic_key_concurrent_limit_returns_concurrent_limit() {
+    let start = GatewayRuntimeHarness::start(GatewayHarnessOptions {
+        generic_key_concurrent_limit: Some(1),
+        ..GatewayHarnessOptions::default()
+    })
+    .await;
+    set_generic_rate_limit_settings(&start.harness, start.generic_key, 10, 10, 86_400_000).await;
+
+    let api_key = start.generic_key.to_string();
+    let _task_id = create_generic_task(&start.harness.service, api_key.as_str(), "robot").await;
+
+    let (status, payload) =
+        post_add_task(&start.harness.service, api_key.as_str(), "robot again").await;
+    assert_eq!(status, StatusCode::TOO_MANY_REQUESTS);
+    assert_eq!(payload["error"], "concurrent_limit");
+    assert_eq!(
+        payload["message"],
+        "Generic key concurrent task limit exceeded."
+    );
+}
+
+#[tokio::test]
+async fn generic_key_default_concurrent_limit_is_two() {
+    let start = GatewayRuntimeHarness::start(GatewayHarnessOptions::default()).await;
+    set_generic_rate_limit_settings(&start.harness, start.generic_key, 10, 10, 86_400_000).await;
+
+    let api_key = start.generic_key.to_string();
+    let _task_a = create_generic_task(&start.harness.service, api_key.as_str(), "robot-a").await;
+    let _task_b = create_generic_task(&start.harness.service, api_key.as_str(), "robot-b").await;
+
+    let (status, payload) =
+        post_add_task(&start.harness.service, api_key.as_str(), "robot-c").await;
+    assert_eq!(status, StatusCode::TOO_MANY_REQUESTS);
+    assert_eq!(payload["error"], "concurrent_limit");
+    assert_eq!(
+        payload["message"],
+        "Generic key concurrent task limit exceeded."
+    );
+}
+
+#[tokio::test]
+async fn generic_key_concurrent_limit_is_shared_across_source_ips_end_to_end() {
+    let start = GatewayRuntimeHarness::start(GatewayHarnessOptions {
+        generic_key_concurrent_limit: Some(1),
+        ..GatewayHarnessOptions::default()
+    })
+    .await;
+    set_generic_rate_limit_settings(&start.harness, start.generic_key, 10, 10, 86_400_000).await;
+
+    let api_key = start.generic_key.to_string();
+    let service_a = service_for_ip(&start.harness, 6);
+    let service_b = service_for_ip(&start.harness, 7);
+
+    let _task_a = create_generic_task(&service_a, api_key.as_str(), "robot-a").await;
+
+    let (status_b, payload_b) = post_add_task(&service_b, api_key.as_str(), "robot-b").await;
+    assert_eq!(status_b, StatusCode::TOO_MANY_REQUESTS);
+    assert_eq!(payload_b["error"], "concurrent_limit");
+    assert_eq!(
+        payload_b["message"],
+        "Generic key concurrent task limit exceeded."
+    );
+}
+
+#[tokio::test]
+async fn generic_key_concurrent_limit_recovers_after_restart_timeout_end_to_end() {
+    let start = GatewayRuntimeHarness::start(GatewayHarnessOptions {
+        taskmanager_cleanup_interval_secs: Some(1),
+        taskmanager_result_lifetime_secs: Some(2),
+        generic_key_concurrent_limit: Some(1),
+        ..GatewayHarnessOptions::default()
+    })
+    .await;
+    set_generic_rate_limit_settings(&start.harness, start.generic_key, 10, 10, 86_400_000).await;
+
+    let api_key = start.generic_key.to_string();
+    let _task_id = create_generic_task(&start.harness.service, api_key.as_str(), "robot").await;
+
+    let (blocked_status, blocked_payload) =
+        post_add_task(&start.harness.service, api_key.as_str(), "robot again").await;
+    assert_eq!(blocked_status, StatusCode::TOO_MANY_REQUESTS);
+    assert_eq!(blocked_payload["error"], "concurrent_limit");
+    assert_eq!(
+        blocked_payload["message"],
+        "Generic key concurrent task limit exceeded."
+    );
+
+    let restarted = start.restart().await;
+
+    let (post_restart_status, post_restart_payload) = post_add_task(
+        &restarted.harness.service,
+        api_key.as_str(),
+        "robot after restart",
+    )
+    .await;
+    assert_eq!(post_restart_status, StatusCode::TOO_MANY_REQUESTS);
+    assert_eq!(post_restart_payload["error"], "concurrent_limit");
+    assert_eq!(
+        post_restart_payload["message"],
+        "Generic key concurrent task limit exceeded."
+    );
+
+    let _task_after_timeout = wait_for_generic_success(
+        &restarted.harness.service,
+        api_key.as_str(),
+        "robot after timeout",
+        Duration::from_secs(12),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn generic_key_global_rolling_window_unblocks_after_expiration() {
+    let start = GatewayRuntimeHarness::start(GatewayHarnessOptions::default()).await;
+    let now_ms = current_time_ms();
+    let key_hash = generic_key_hash(
+        start.harness.config.http.api_key_secret.as_str(),
+        "global-ip",
+    );
+
+    let first =
+        submit_generic_task_with_now(&start.harness, now_ms, 1, 10, 60_000, &key_hash).await;
+    assert!(
+        first.ok,
+        "first generic rolling-window task should succeed: {first:?}"
+    );
+
+    let blocked =
+        submit_generic_task_with_now(&start.harness, now_ms + 1, 1, 10, 60_000, &key_hash).await;
+    assert!(
+        !blocked.ok,
+        "second global generic task should be blocked: {blocked:?}"
+    );
+    assert_eq!(blocked.error_code.as_deref(), Some("daily_limit"));
+    assert_eq!(
+        blocked.error_message.as_deref(),
+        Some("Generic key global rolling limit exceeded.")
+    );
+
+    let after_expiry =
+        submit_generic_task_with_now(&start.harness, now_ms + 60_001, 1, 10, 60_000, &key_hash)
+            .await;
+    assert!(
+        after_expiry.ok,
+        "generic global rolling window should unblock after expiration: {after_expiry:?}"
+    );
+}
+
+#[tokio::test]
+async fn generic_key_per_ip_rolling_window_unblocks_after_expiration() {
+    let start = GatewayRuntimeHarness::start(GatewayHarnessOptions::default()).await;
+    let now_ms = current_time_ms();
+    let key_hash = generic_key_hash(start.harness.config.http.api_key_secret.as_str(), "per-ip");
+
+    let first =
+        submit_generic_task_with_now(&start.harness, now_ms, 10, 1, 60_000, &key_hash).await;
+    assert!(
+        first.ok,
+        "first generic per-ip rolling task should succeed: {first:?}"
+    );
+
+    let blocked =
+        submit_generic_task_with_now(&start.harness, now_ms + 1, 10, 1, 60_000, &key_hash).await;
+    assert!(
+        !blocked.ok,
+        "second per-ip generic task should be blocked: {blocked:?}"
+    );
+    assert_eq!(blocked.error_code.as_deref(), Some("daily_limit"));
+    assert_eq!(
+        blocked.error_message.as_deref(),
+        Some("Generic key per-IP rolling limit exceeded.")
+    );
+
+    let after_expiry =
+        submit_generic_task_with_now(&start.harness, now_ms + 60_001, 10, 1, 60_000, &key_hash)
+            .await;
+    assert!(
+        after_expiry.ok,
+        "generic per-ip rolling window should unblock after expiration: {after_expiry:?}"
+    );
+}

--- a/tests/client_http_api/mod.rs
+++ b/tests/client_http_api/mod.rs
@@ -2,6 +2,7 @@
 mod common;
 
 mod add_task;
+mod generic_rate_limits;
 mod get_result;
 mod get_status;
 mod get_tasks;

--- a/tests/common/real_harness.rs
+++ b/tests/common/real_harness.rs
@@ -1,4 +1,4 @@
-use std::net::{TcpListener, UdpSocket};
+use std::net::{IpAddr, TcpListener, UdpSocket};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -56,6 +56,18 @@ impl TestService {
         Self {
             base_url,
             client: HttpClient::new(),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn with_local_address(&self, addr: IpAddr) -> Self {
+        let client = HttpClient::builder()
+            .local_address(addr)
+            .build()
+            .expect("build local-address test client");
+        Self {
+            base_url: self.base_url.clone(),
+            client,
         }
     }
 
@@ -182,6 +194,7 @@ pub(crate) struct GatewayHarnessOptions {
     pub(crate) taskmanager_cleanup_interval_secs: Option<u64>,
     pub(crate) taskmanager_result_lifetime_secs: Option<u64>,
     pub(crate) api_keys_update_interval_secs: Option<u64>,
+    pub(crate) generic_key_concurrent_limit: Option<usize>,
 }
 
 impl Default for GatewayHarnessOptions {
@@ -192,6 +205,7 @@ impl Default for GatewayHarnessOptions {
             taskmanager_cleanup_interval_secs: None,
             taskmanager_result_lifetime_secs: None,
             api_keys_update_interval_secs: None,
+            generic_key_concurrent_limit: None,
         }
     }
 }
@@ -237,6 +251,94 @@ pub(crate) struct GatewayRuntimeStart {
     pub(crate) default_user_api_key: String,
     pub(crate) default_company_api_key: String,
     pub(crate) company_id: Uuid,
+}
+
+impl GatewayRuntimeStart {
+    #[allow(dead_code)]
+    pub(crate) async fn restart(self) -> Self {
+        let GatewayRuntimeStart {
+            harness,
+            runtime_config: _runtime_config,
+            config_path,
+            generic_key,
+            admin_key,
+            default_user_api_key,
+            default_company_api_key,
+            company_id,
+        } = self;
+        let harness = std::mem::ManuallyDrop::new(harness);
+        let old_service = unsafe { std::ptr::read(&harness.service) };
+        let config = unsafe { std::ptr::read(&harness.config) };
+        let old_gateway = unsafe { std::ptr::read(&harness.gateway) };
+        let db_client = unsafe { std::ptr::read(&harness.db_client) };
+        let db_connection_task = unsafe { std::ptr::read(&harness._db_connection_task) };
+        let db_lease = unsafe { std::ptr::read(&harness._db_lease) };
+        let config_file = unsafe { std::ptr::read(&harness._config_file) };
+        let temp_dir = unsafe { std::ptr::read(&harness._temp_dir) };
+        let old_shutdown = unsafe { std::ptr::read(&harness._shutdown) };
+
+        drop(old_gateway);
+        drop(old_shutdown);
+        drop(old_service);
+
+        let mut config = (*config).clone();
+        config.http.port = reserve_tcp_port().expect("reserve restarted HTTP port");
+        config.network.server_port = reserve_udp_port().expect("reserve restarted raft port");
+        std::fs::write(
+            &config_path,
+            toml::to_string(&config).expect("serialize restarted test config"),
+        )
+        .expect("write restarted test config");
+
+        let runtime_config = Arc::new(
+            RuntimeConfigStore::new(config_path.clone(), config.clone())
+                .await
+                .expect("restart runtime config"),
+        );
+        let shutdown = CancellationToken::new();
+        let gateway = gateway::raft::start_gateway(
+            GatewayMode::Single,
+            Arc::clone(&runtime_config),
+            shutdown.clone(),
+        )
+        .await
+        .expect("restart gateway");
+
+        let service = TestService::new(format!("http://127.0.0.1:{}", config.http.port));
+        wait_for_http_ready(&service)
+            .await
+            .expect("wait for restarted HTTP server");
+        gateway
+            .sync_db_caches_for_test()
+            .await
+            .expect("sync restarted db caches");
+        if config.basic.update_gateway_info_ms < 60_000 {
+            wait_for_gateway_info(&service)
+                .await
+                .expect("wait for restarted gateway info");
+        }
+
+        Self {
+            harness: GatewayRuntimeHarness {
+                service,
+                config: Arc::new(config),
+                gateway,
+                db_client,
+                _db_connection_task: db_connection_task,
+                _db_lease: db_lease,
+                _config_file: config_file,
+                _temp_dir: temp_dir,
+                _shutdown: shutdown,
+            },
+            runtime_config,
+            config_path,
+            generic_key,
+            admin_key,
+            default_user_api_key,
+            default_company_api_key,
+            company_id,
+        }
+    }
 }
 
 struct SharedPostgresEnv {
@@ -435,6 +537,9 @@ impl GatewayRuntimeHarness {
         }
         if let Some(result_lifetime_secs) = options.taskmanager_result_lifetime_secs {
             config.basic.taskmanager_result_lifetime = result_lifetime_secs;
+        }
+        if let Some(generic_key_concurrent_limit) = options.generic_key_concurrent_limit {
+            config.http.generic_key_concurrent_limit = generic_key_concurrent_limit;
         }
 
         let generic_key = config.http.generic_key.expect("generic key");

--- a/tests/event_tracker/activity.rs
+++ b/tests/event_tracker/activity.rs
@@ -3,12 +3,13 @@ use std::sync::Arc;
 use http::StatusCode;
 use uuid::Uuid;
 
-use gateway::crypto::hotkey::Hotkey;
 use gateway::test_support::{CompanyRateLimit, RateLimitContext};
 
 use crate::support::{
-    TestClient, add_success_result, build_harness, default_rate_ctx, multipart_add_task,
-    read_response, tiny_png_bytes, wait_for_activity,
+    AddResultMultipartInput, TestClient, analytics_foreign_key_columns, build_harness,
+    default_rate_ctx, multipart_add_result, multipart_add_task,
+    purge_terminal_generation_task_in_db, read_response, record_assignment_in_memory_and_db,
+    sign_worker, timeout_generation_task_in_db, tiny_png_bytes, wait_for_activity,
 };
 
 #[tokio::test]
@@ -27,13 +28,31 @@ async fn records_client_activity_events() {
     let task_id = payload.get("id").and_then(|v| v.as_str()).expect("id");
     let task_id = Uuid::parse_str(task_id).expect("uuid");
 
-    add_success_result(
-        &h.task_manager,
+    let (worker_hotkey, timestamp, signature) = sign_worker([42u8; 32]);
+    let assignment_token =
+        record_assignment_in_memory_and_db(&h, task_id, &worker_hotkey, "worker-1").await;
+    let (boundary, body) = multipart_add_result(AddResultMultipartInput {
         task_id,
-        Hotkey::from_bytes(&[42u8; 32]),
-        b"spz".to_vec(),
-    )
-    .await;
+        worker_hotkey: &worker_hotkey,
+        worker_id: "worker-1",
+        assignment_token,
+        timestamp: &timestamp,
+        signature: &signature,
+        status: "success",
+        asset: Some(b"spz"),
+        reason: None,
+    });
+    let res = TestClient::post("http://localhost/add_result")
+        .add_header(
+            "content-type",
+            format!("multipart/form-data; boundary={}", boundary),
+            true,
+        )
+        .body(body)
+        .send(&h.service)
+        .await;
+    let (status, _headers, _body) = read_response(res).await;
+    assert_eq!(status, StatusCode::OK);
 
     let res = TestClient::get(format!("http://localhost/get_result?id={task_id}"))
         .add_header("x-api-key", h.api_key.to_string(), true)
@@ -57,16 +76,18 @@ async fn records_client_activity_events() {
     assert_eq!(add_task.task_id, Some(task_id));
     assert_eq!(add_task.client_origin, "api");
     assert_eq!(add_task.model.as_deref(), Some("404-3dgs"));
+    assert!(add_task.account_id.is_some());
 
     let get_result = rows
         .iter()
         .find(|r| r.action == "get_result")
         .expect("get_result");
     assert_eq!(get_result.event_family, "other");
-    assert_eq!(get_result.task_kind.as_deref(), Some("unknown"));
+    assert_eq!(get_result.task_kind.as_deref(), Some("txt3d"));
     assert_eq!(get_result.task_id, Some(task_id));
     assert_eq!(get_result.client_origin, "api");
-    assert!(get_result.model.is_none());
+    assert_eq!(get_result.model.as_deref(), Some("404-3dgs"));
+    assert!(get_result.account_id.is_some());
 }
 
 #[tokio::test]
@@ -112,6 +133,7 @@ async fn records_company_activity_with_image_task() {
     assert_eq!(add_task.task_kind.as_deref(), Some("img3d"));
     assert_eq!(add_task.task_id, Some(task_id));
     assert_eq!(add_task.client_origin, "blender");
+    assert!(add_task.account_id.is_some());
     assert_eq!(add_task.company_id, Some(company_id));
     assert_eq!(add_task.company_name.as_deref(), Some("Acme"));
     assert_eq!(add_task.model.as_deref(), Some("404-3dgs"));
@@ -142,6 +164,7 @@ async fn records_generic_key_activity_event() {
         .expect("add_task");
     assert_eq!(add_task.event_family, "other");
     assert_eq!(add_task.client_origin, "blender");
+    assert!(add_task.account_id.is_none());
     assert!(add_task.user_id.is_none());
     assert!(add_task.company_id.is_none());
 }
@@ -171,6 +194,53 @@ async fn records_generic_key_activity_event_for_unity_origin() {
         .expect("add_task");
     assert_eq!(add_task.event_family, "other");
     assert_eq!(add_task.client_origin, "unity");
+    assert!(add_task.account_id.is_none());
     assert!(add_task.user_id.is_none());
     assert!(add_task.company_id.is_none());
+}
+
+#[tokio::test]
+async fn activity_event_task_id_survives_generation_task_purge() {
+    let h = build_harness(default_rate_ctx(), None).await;
+
+    let res = TestClient::post("http://localhost/add_task")
+        .add_header("x-api-key", h.api_key.to_string(), true)
+        .add_header("x-client-origin", "api", true)
+        .json(&serde_json::json!({"prompt": "robot"}))
+        .send(&h.service)
+        .await;
+    let (status, _headers, body) = read_response(res).await;
+    assert_eq!(status, StatusCode::OK);
+    let payload: serde_json::Value = serde_json::from_slice(&body).expect("json response");
+    let task_id = payload.get("id").and_then(|v| v.as_str()).expect("id");
+    let task_id = Uuid::parse_str(task_id).expect("uuid");
+
+    let rows_before_purge = wait_for_activity(&h, 1).await;
+    let add_task = rows_before_purge
+        .iter()
+        .find(|row| row.action == "add_task")
+        .expect("add_task before purge");
+    assert_eq!(add_task.task_id, Some(task_id));
+
+    timeout_generation_task_in_db(&h, task_id).await;
+    purge_terminal_generation_task_in_db(&h, task_id).await;
+
+    let rows_after_purge = wait_for_activity(&h, 1).await;
+    let add_task = rows_after_purge
+        .iter()
+        .find(|row| row.action == "add_task")
+        .expect("add_task after purge");
+    assert_eq!(add_task.task_id, Some(task_id));
+}
+
+#[tokio::test]
+async fn analytics_event_tables_have_no_mutating_foreign_keys() {
+    let h = build_harness(default_rate_ctx(), None).await;
+
+    let foreign_keys = analytics_foreign_key_columns(&h).await;
+    assert_eq!(
+        foreign_keys,
+        Vec::<(String, String)>::new(),
+        "analytics tables must keep historical ids immutable"
+    );
 }

--- a/tests/event_tracker/support.rs
+++ b/tests/event_tracker/support.rs
@@ -29,6 +29,7 @@ const GATEWAY_PREFIX: &str = "404_GATEWAY_";
 
 #[derive(Debug, Clone)]
 pub(crate) struct ActivityEventRecord {
+    pub(crate) account_id: Option<i64>,
     pub(crate) user_id: Option<i64>,
     pub(crate) company_id: Option<Uuid>,
     pub(crate) company_name: Option<String>,
@@ -46,7 +47,9 @@ pub(crate) struct WorkerEventRecord {
     pub(crate) worker_id: Option<String>,
     pub(crate) action: String,
     pub(crate) task_kind: String,
+    pub(crate) model: Option<String>,
     pub(crate) reason: Option<String>,
+    pub(crate) metadata_json: Value,
 }
 
 fn ensure_crypto_provider() {
@@ -394,6 +397,84 @@ pub(crate) async fn wait_for_worker(
         .expect("fetch worker events")
 }
 
+pub(crate) async fn analytics_foreign_key_columns(harness: &EventHarness) -> Vec<(String, String)> {
+    let rows = harness
+        .core
+        .db_client
+        .query(
+            "SELECT tc.table_name, kcu.column_name
+             FROM information_schema.table_constraints AS tc
+             JOIN information_schema.key_column_usage AS kcu
+               ON tc.constraint_name = kcu.constraint_name
+              AND tc.table_schema = kcu.table_schema
+              AND tc.table_name = kcu.table_name
+             WHERE tc.constraint_type = 'FOREIGN KEY'
+               AND tc.table_schema = 'public'
+               AND tc.table_name IN ('activity_events', 'worker_events')
+             ORDER BY tc.table_name ASC, kcu.ordinal_position ASC, kcu.column_name ASC",
+            &[],
+        )
+        .await
+        .expect("query analytics foreign keys");
+    rows.into_iter()
+        .map(|row| (row.get("table_name"), row.get("column_name")))
+        .collect()
+}
+
+pub(crate) async fn purge_terminal_generation_task_in_db(harness: &EventHarness, task_id: Uuid) {
+    let completed_before_ms = current_timestamp() as i64 * 1000;
+    let rows = harness
+        .core
+        .db_client
+        .query(
+            "SELECT task_id
+             FROM generation_purge_terminal_tasks($1, $2)",
+            &[&100_i32, &completed_before_ms],
+        )
+        .await
+        .expect("purge terminal generation tasks");
+    assert!(
+        rows.iter()
+            .any(|row| row.get::<_, Uuid>("task_id") == task_id),
+        "expected generation_purge_terminal_tasks to purge task {task_id}"
+    );
+}
+
+pub(crate) async fn timeout_generation_task_in_db(harness: &EventHarness, task_id: Uuid) {
+    let now = current_timestamp() as i64 * 1000;
+    let updated = harness
+        .core
+        .db_client
+        .execute(
+            "UPDATE generation_tasks
+             SET deadline_at = $2
+             WHERE id = $1",
+            &[&task_id, &(now - 1)],
+        )
+        .await
+        .expect("move generation task deadline into the past");
+    assert_eq!(
+        updated, 1,
+        "expected exactly one generation task row to update"
+    );
+
+    let rows = harness
+        .core
+        .db_client
+        .query(
+            "SELECT task_id
+             FROM generation_expire_tasks($1, $2)",
+            &[&100_i32, &now],
+        )
+        .await
+        .expect("expire generation tasks");
+    assert!(
+        rows.iter()
+            .any(|row| row.get::<_, Uuid>("task_id") == task_id),
+        "expected generation_expire_tasks to expire task {task_id}"
+    );
+}
+
 pub(crate) async fn add_success_result(
     task_manager: &TaskManager,
     task_id: Uuid,
@@ -511,7 +592,7 @@ async fn fetch_activity_events(
     let rows = harness
         .db_client
         .query(
-            "SELECT task_id, user_id, company_id, action, event_family, client_origin, task_kind, model, metadata_json::TEXT AS metadata_json FROM activity_events ORDER BY created_at ASC, id ASC",
+            "SELECT task_id, account_id, user_id, company_id, action, event_family, client_origin, task_kind, model, metadata_json::TEXT AS metadata_json FROM activity_events ORDER BY created_at ASC, id ASC",
             &[],
         )
         .await
@@ -522,6 +603,7 @@ async fn fetch_activity_events(
             let metadata: Value = serde_json::from_str(&metadata_text).unwrap_or(Value::Null);
             Ok(ActivityEventRecord {
                 task_id: row.get("task_id"),
+                account_id: row.get("account_id"),
                 user_id: row.get("user_id"),
                 company_id: row.get("company_id"),
                 company_name: metadata
@@ -542,19 +624,25 @@ async fn fetch_worker_events(harness: &GatewayRuntimeHarness) -> Result<Vec<Work
     let rows = harness
         .db_client
         .query(
-            "SELECT task_id, worker_id, action, task_kind, reason FROM worker_events ORDER BY created_at ASC, id ASC",
+            "SELECT task_id, worker_id, action, task_kind, model, reason, metadata_json::TEXT AS metadata_json FROM worker_events ORDER BY created_at ASC, id ASC",
             &[],
         )
         .await
         .context("query worker events")?;
     Ok(rows
         .into_iter()
-        .map(|row| WorkerEventRecord {
-            task_id: row.get("task_id"),
-            worker_id: row.get("worker_id"),
-            action: row.get("action"),
-            task_kind: row.get("task_kind"),
-            reason: row.get("reason"),
+        .map(|row| {
+            let metadata_text: String = row.get("metadata_json");
+            let metadata_json: Value = serde_json::from_str(&metadata_text).unwrap_or(Value::Null);
+            WorkerEventRecord {
+                task_id: row.get("task_id"),
+                worker_id: row.get("worker_id"),
+                action: row.get("action"),
+                task_kind: row.get("task_kind"),
+                model: row.get("model"),
+                reason: row.get("reason"),
+                metadata_json,
+            }
         })
         .collect())
 }

--- a/tests/event_tracker/worker.rs
+++ b/tests/event_tracker/worker.rs
@@ -8,8 +8,8 @@ use gateway::test_support::RateLimitContext;
 use crate::common::GatewayHarnessOptions;
 use crate::support::{
     AddResultMultipartInput, TestClient, build_harness, build_harness_with_options,
-    default_rate_ctx, multipart_add_result, read_response, sign_worker, tiny_png_bytes,
-    wait_for_worker,
+    default_rate_ctx, multipart_add_result, purge_terminal_generation_task_in_db, read_response,
+    sign_worker, timeout_generation_task_in_db, tiny_png_bytes, wait_for_worker,
 };
 
 #[tokio::test]
@@ -36,6 +36,7 @@ async fn records_worker_events() {
         .expect("task id");
 
     let (worker_hotkey, timestamp, signature) = sign_worker([1u8; 32]);
+    let worker_hotkey_str = worker_hotkey.to_string();
     let res = TestClient::post("http://localhost/get_tasks")
         .json(&serde_json::json!({
             "worker_hotkey": worker_hotkey.to_string(),
@@ -95,7 +96,16 @@ async fn records_worker_events() {
         .expect("assigned");
     assert_eq!(assigned.task_id, Some(task_id));
     assert_eq!(assigned.task_kind, "txt3d");
+    assert_eq!(assigned.model.as_deref(), Some("404-3dgs"));
     assert_eq!(assigned.worker_id.as_deref(), Some("worker-1"));
+    assert_eq!(
+        assigned.metadata_json["worker_hotkey"].as_str(),
+        Some(worker_hotkey_str.as_str())
+    );
+    assert_eq!(
+        assigned.metadata_json["assignment_token"],
+        serde_json::json!(assignment_token)
+    );
 
     let success = rows
         .iter()
@@ -103,7 +113,20 @@ async fn records_worker_events() {
         .expect("success");
     assert_eq!(success.task_id, Some(task_id));
     assert_eq!(success.task_kind, "txt3d");
+    assert_eq!(success.model.as_deref(), Some("404-3dgs"));
     assert_eq!(success.worker_id.as_deref(), Some("worker-1"));
+    assert_eq!(
+        success.metadata_json["worker_hotkey"].as_str(),
+        Some(worker_hotkey_str.as_str())
+    );
+    assert_eq!(
+        success.metadata_json["assignment_token"],
+        serde_json::json!(assignment_token)
+    );
+    assert_eq!(
+        success.metadata_json["replayed_durable_result"],
+        serde_json::json!(false)
+    );
 }
 
 #[tokio::test]
@@ -130,6 +153,7 @@ async fn records_worker_failure_event() {
         .expect("task id");
 
     let (worker_hotkey, timestamp, signature) = sign_worker([1u8; 32]);
+    let worker_hotkey_str = worker_hotkey.to_string();
     let res = TestClient::post("http://localhost/get_tasks")
         .json(&serde_json::json!({
             "worker_hotkey": worker_hotkey.to_string(),
@@ -185,8 +209,21 @@ async fn records_worker_failure_event() {
         .expect("result_failure");
     assert_eq!(failure.task_id, Some(task_id));
     assert_eq!(failure.task_kind, "txt3d");
+    assert_eq!(failure.model.as_deref(), Some("404-3dgs"));
     assert_eq!(failure.reason.as_deref(), Some("bad model output"));
     assert_eq!(failure.worker_id.as_deref(), Some("worker-1"));
+    assert_eq!(
+        failure.metadata_json["worker_hotkey"].as_str(),
+        Some(worker_hotkey_str.as_str())
+    );
+    assert_eq!(
+        failure.metadata_json["assignment_token"],
+        serde_json::json!(assignment_token)
+    );
+    assert_eq!(
+        failure.metadata_json["replayed_durable_result"],
+        serde_json::json!(false)
+    );
 }
 
 #[tokio::test]
@@ -227,6 +264,7 @@ async fn records_worker_timeout_event() {
         .expect("task id");
 
     let (worker_hotkey, timestamp, signature) = sign_worker([3u8; 32]);
+    let worker_hotkey_str = worker_hotkey.to_string();
     let res = TestClient::post("http://localhost/get_tasks")
         .json(&serde_json::json!({
             "worker_hotkey": worker_hotkey.to_string(),
@@ -255,5 +293,72 @@ async fn records_worker_timeout_event() {
         .expect("timeout");
     assert_eq!(timeout.task_id, Some(task_id));
     assert_eq!(timeout.task_kind, "txt3d");
+    assert_eq!(timeout.model.as_deref(), Some("404-3dgs"));
     assert_eq!(timeout.worker_id.as_deref(), Some("worker-3"));
+    assert_eq!(
+        timeout.metadata_json["worker_hotkey"].as_str(),
+        Some(worker_hotkey_str.as_str())
+    );
+}
+
+#[tokio::test]
+async fn worker_event_task_id_survives_generation_task_purge() {
+    let h = build_harness(default_rate_ctx(), None).await;
+
+    let create = TestClient::post("http://localhost/add_task")
+        .add_header("x-api-key", h.api_key.to_string(), true)
+        .json(&serde_json::json!({"prompt": "robot"}))
+        .send(&h.service)
+        .await;
+    let (create_status, _headers, create_body) = read_response(create).await;
+    assert_eq!(
+        create_status,
+        StatusCode::OK,
+        "add_task body: {}",
+        String::from_utf8_lossy(&create_body)
+    );
+    let payload: serde_json::Value = serde_json::from_slice(&create_body).expect("json response");
+    let task_id = payload
+        .get("id")
+        .and_then(|value| value.as_str())
+        .and_then(|value| Uuid::parse_str(value).ok())
+        .expect("task id");
+
+    let (worker_hotkey, timestamp, signature) = sign_worker([4u8; 32]);
+    let res = TestClient::post("http://localhost/get_tasks")
+        .json(&serde_json::json!({
+            "worker_hotkey": worker_hotkey.to_string(),
+            "worker_id": "worker-4",
+            "signature": signature,
+            "timestamp": timestamp,
+            "requested_task_count": 1,
+            "model": "404-3dgs"
+        }))
+        .send(&h.service)
+        .await;
+    let (status, _headers, body) = read_response(res).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "get_tasks body: {}",
+        String::from_utf8_lossy(&body)
+    );
+
+    let rows_before_purge = wait_for_worker(&h, 1).await;
+    let assigned_before_purge = rows_before_purge
+        .iter()
+        .find(|row| row.action == "task_assigned")
+        .expect("task_assigned before purge");
+    assert_eq!(assigned_before_purge.task_id, Some(task_id));
+
+    timeout_generation_task_in_db(&h, task_id).await;
+
+    purge_terminal_generation_task_in_db(&h, task_id).await;
+
+    let rows_after_purge = wait_for_worker(&h, 1).await;
+    let assigned = rows_after_purge
+        .iter()
+        .find(|row| row.action == "task_assigned")
+        .expect("task_assigned");
+    assert_eq!(assigned.task_id, Some(task_id));
 }


### PR DESCRIPTION
Move generic-key concurrency into gateway config (shared per generic key, default 2), release stuck slots after restart, and preserve correct task_kind/model and IDs in analytics.