### PR TITLE
Improve refund policy

### DIFF
--- a/dev-env/config/config-single.toml
+++ b/dev-env/config/config-single.toml
@@ -92,7 +92,9 @@ max_rate_limit_deltas_per_batch = 8192
 unique_workers_per_task = 3
 taskmanager_initial_capacity = 1024
 taskmanager_cleanup_interval = 30
-taskmanager_result_lifetime = 2000
+# Task lifetime controls worker deadline/refunds; result lifetime controls in-memory result retention.
+taskmanager_task_lifetime = 600
+taskmanager_result_lifetime = 300
 taskqueue_cleanup_interval = 1
 taskqueue_task_ttl = 1800
 generation_task_retention_sec = 86400

--- a/dev-env/config/config1.toml
+++ b/dev-env/config/config1.toml
@@ -92,7 +92,9 @@ max_rate_limit_deltas_per_batch = 8192
 unique_workers_per_task = 3
 taskmanager_initial_capacity = 1024
 taskmanager_cleanup_interval = 30
-taskmanager_result_lifetime = 2000
+# Task lifetime controls worker deadline/refunds; result lifetime controls in-memory result retention.
+taskmanager_task_lifetime = 600
+taskmanager_result_lifetime = 300
 taskqueue_cleanup_interval = 1
 taskqueue_task_ttl = 1800
 generation_task_retention_sec = 86400

--- a/dev-env/config/config2.toml
+++ b/dev-env/config/config2.toml
@@ -92,7 +92,9 @@ max_rate_limit_deltas_per_batch = 8192
 unique_workers_per_task = 3
 taskmanager_initial_capacity = 1024
 taskmanager_cleanup_interval = 30
-taskmanager_result_lifetime = 2000
+# Task lifetime controls worker deadline/refunds; result lifetime controls in-memory result retention.
+taskmanager_task_lifetime = 600
+taskmanager_result_lifetime = 300
 taskqueue_cleanup_interval = 1
 taskqueue_task_ttl = 1800
 generation_task_retention_sec = 86400

--- a/dev-env/config/config3.toml
+++ b/dev-env/config/config3.toml
@@ -92,7 +92,9 @@ max_rate_limit_deltas_per_batch = 8192
 unique_workers_per_task = 3
 taskmanager_initial_capacity = 1024
 taskmanager_cleanup_interval = 30
-taskmanager_result_lifetime = 2000
+# Task lifetime controls worker deadline/refunds; result lifetime controls in-memory result retention.
+taskmanager_task_lifetime = 600
+taskmanager_result_lifetime = 300
 taskqueue_cleanup_interval = 1
 taskqueue_task_ttl = 1800
 generation_task_retention_sec = 86400

--- a/dev-env/init-scripts/init-schema.sql
+++ b/dev-env/init-scripts/init-schema.sql
@@ -69,6 +69,8 @@ CREATE TABLE IF NOT EXISTS app_settings (
   rate_limit_whitelist TEXT[] NOT NULL,
   max_task_queue_len INTEGER NOT NULL CHECK (max_task_queue_len >= 0),
   request_file_size_limit BIGINT NOT NULL CHECK (request_file_size_limit >= 0),
+  taskmanager_task_lifetime_sec INTEGER NOT NULL DEFAULT 600 CHECK (taskmanager_task_lifetime_sec > 0),
+  taskmanager_result_lifetime_sec INTEGER NOT NULL DEFAULT 300 CHECK (taskmanager_result_lifetime_sec > 0),
   stripe_enabled BOOLEAN NOT NULL DEFAULT TRUE,
   created_at BIGINT NOT NULL,
   updated_at BIGINT NOT NULL
@@ -93,6 +95,8 @@ BEGIN
     rate_limit_whitelist,
     max_task_queue_len,
     request_file_size_limit,
+    taskmanager_task_lifetime_sec,
+    taskmanager_result_lifetime_sec,
     stripe_enabled,
     created_at,
     updated_at
@@ -112,6 +116,8 @@ BEGIN
     ARRAY[]::TEXT[],
     500,
     157286400,
+    600,
+    300,
     TRUE,
     v_now,
     v_now

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,6 +24,9 @@ pub struct BasicConfig {
     pub unique_workers_per_task: usize,
     pub taskmanager_initial_capacity: usize,
     pub taskmanager_cleanup_interval: u64,
+    #[serde(default = "default_taskmanager_task_lifetime")]
+    pub taskmanager_task_lifetime: u64,
+    #[serde(default = "default_taskmanager_result_lifetime")]
     pub taskmanager_result_lifetime: u64,
     pub taskqueue_cleanup_interval: u64,
     pub taskqueue_task_ttl: u64,
@@ -33,6 +36,14 @@ pub struct BasicConfig {
 
 fn default_generation_task_retention_sec() -> u64 {
     86_400
+}
+
+fn default_taskmanager_task_lifetime() -> u64 {
+    600
+}
+
+fn default_taskmanager_result_lifetime() -> u64 {
+    300
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/src/db/data_access.rs
+++ b/src/db/data_access.rs
@@ -25,6 +25,8 @@ pub struct GatewaySettingsRow {
     pub rate_limit_whitelist: Vec<String>,
     pub max_task_queue_len: u64,
     pub request_file_size_limit: u64,
+    pub taskmanager_task_lifetime_sec: u64,
+    pub taskmanager_result_lifetime_sec: u64,
     pub guest_generation_limit: u64,
     pub guest_window_ms: u64,
     pub registered_generation_limit: u64,
@@ -119,6 +121,8 @@ fn decode_gateway_settings_row(row: Row) -> Result<GatewaySettingsRow> {
         row.get("add_task_unauthorized_per_ip_daily_rate_limit");
     let max_task_queue_len: i32 = row.get("max_task_queue_len");
     let request_file_size_limit: i64 = row.get("request_file_size_limit");
+    let taskmanager_task_lifetime_sec: i32 = row.get("taskmanager_task_lifetime_sec");
+    let taskmanager_result_lifetime_sec: i32 = row.get("taskmanager_result_lifetime_sec");
     let guest_generation_limit: i32 = row.get("guest_generation_limit");
     let guest_window_ms: i64 = row.get("guest_window_ms");
     let registered_generation_limit: i32 = row.get("registered_generation_limit");
@@ -143,6 +147,14 @@ fn decode_gateway_settings_row(row: Row) -> Result<GatewaySettingsRow> {
         request_file_size_limit: nonnegative_i64_to_u64(
             request_file_size_limit,
             "request_file_size_limit",
+        )?,
+        taskmanager_task_lifetime_sec: nonnegative_i32_to_u64(
+            taskmanager_task_lifetime_sec,
+            "taskmanager_task_lifetime_sec",
+        )?,
+        taskmanager_result_lifetime_sec: nonnegative_i32_to_u64(
+            taskmanager_result_lifetime_sec,
+            "taskmanager_result_lifetime_sec",
         )?,
         guest_generation_limit: nonnegative_i32_to_u64(
             guest_generation_limit,
@@ -289,6 +301,8 @@ SELECT
   rate_limit_whitelist,
   max_task_queue_len,
   request_file_size_limit,
+  taskmanager_task_lifetime_sec,
+  taskmanager_result_lifetime_sec,
   guest_generation_limit,
   guest_window_ms,
   registered_generation_limit,

--- a/src/db/gateway_settings.rs
+++ b/src/db/gateway_settings.rs
@@ -14,11 +14,14 @@ use uuid::Uuid;
 use super::Database;
 use super::data_access::GatewaySettingsRow;
 use crate::http3::whitelist::resolve_rate_limit_whitelist_with_status;
+use crate::task::TaskManager;
 
 const DEFAULT_REGISTERED_GENERATION_LIMIT: u64 = 0;
 const DEFAULT_REGISTERED_WINDOW_MS: u64 = 24 * 60 * 60 * 1000;
 const DEFAULT_GUEST_GENERATION_LIMIT: u64 = 1;
 const DEFAULT_GUEST_WINDOW_MS: u64 = 24 * 60 * 60 * 1000;
+const DEFAULT_TASKMANAGER_TASK_LIFETIME_SEC: u64 = 600;
+const DEFAULT_TASKMANAGER_RESULT_LIFETIME_SEC: u64 = 300;
 
 pub fn gateway_settings_sync_interval(update_interval_secs: u64) -> Duration {
     Duration::from_secs(update_interval_secs.max(1))
@@ -33,6 +36,8 @@ struct CachedGatewaySettings {
     add_task_unauthorized_per_ip_daily_rate_limit: u64,
     max_task_queue_len: u64,
     request_file_size_limit: u64,
+    taskmanager_task_lifetime_sec: u64,
+    taskmanager_result_lifetime_sec: u64,
     guest_generation_limit: u64,
     guest_window_ms: u64,
     registered_generation_limit: u64,
@@ -56,6 +61,8 @@ pub struct GatewayRuntimeSettingsStore {
     add_task_unauthorized_per_ip_daily_rate_limit: AtomicU64,
     max_task_queue_len: AtomicU64,
     request_file_size_limit: AtomicU64,
+    taskmanager_task_lifetime_sec: AtomicU64,
+    taskmanager_result_lifetime_sec: AtomicU64,
     guest_generation_limit: AtomicU64,
     guest_window_ms: AtomicU64,
     registered_generation_limit: AtomicU64,
@@ -82,6 +89,10 @@ impl GatewayRuntimeSettingsStore {
             add_task_unauthorized_per_ip_daily_rate_limit: AtomicU64::new(0),
             max_task_queue_len: AtomicU64::new(0),
             request_file_size_limit: AtomicU64::new(0),
+            taskmanager_task_lifetime_sec: AtomicU64::new(DEFAULT_TASKMANAGER_TASK_LIFETIME_SEC),
+            taskmanager_result_lifetime_sec: AtomicU64::new(
+                DEFAULT_TASKMANAGER_RESULT_LIFETIME_SEC,
+            ),
             guest_generation_limit: AtomicU64::new(DEFAULT_GUEST_GENERATION_LIMIT),
             guest_window_ms: AtomicU64::new(DEFAULT_GUEST_WINDOW_MS),
             registered_generation_limit: AtomicU64::new(DEFAULT_REGISTERED_GENERATION_LIMIT),
@@ -90,7 +101,11 @@ impl GatewayRuntimeSettingsStore {
         }
     }
 
-    pub async fn run(self: Arc<Self>, shutdown: CancellationToken) {
+    pub async fn run(
+        self: Arc<Self>,
+        task_manager: Option<TaskManager>,
+        shutdown: CancellationToken,
+    ) {
         let mut interval = tokio::time::interval(self.update_interval);
         loop {
             tokio::select! {
@@ -98,6 +113,13 @@ impl GatewayRuntimeSettingsStore {
                 _ = interval.tick() => {
                     if let Err(err) = self.refresh_once().await {
                         error!("Error updating gateway settings: {:?}", err);
+                    } else if self.has_database_gateway_settings()
+                        && let Some(task_manager) = task_manager.as_ref()
+                    {
+                        task_manager.set_lifetimes(
+                            Duration::from_secs(self.taskmanager_task_lifetime_sec().max(1)),
+                            Duration::from_secs(self.taskmanager_result_lifetime_sec().max(1)),
+                        );
                     }
                 }
             }
@@ -132,6 +154,12 @@ impl GatewayRuntimeSettingsStore {
                 .load(Ordering::Acquire),
             max_task_queue_len: self.max_task_queue_len.load(Ordering::Acquire),
             request_file_size_limit: self.request_file_size_limit.load(Ordering::Acquire),
+            taskmanager_task_lifetime_sec: self
+                .taskmanager_task_lifetime_sec
+                .load(Ordering::Acquire),
+            taskmanager_result_lifetime_sec: self
+                .taskmanager_result_lifetime_sec
+                .load(Ordering::Acquire),
             guest_generation_limit: self.guest_generation_limit.load(Ordering::Acquire),
             guest_window_ms: self.guest_window_ms.load(Ordering::Acquire),
             registered_generation_limit: self.registered_generation_limit.load(Ordering::Acquire),
@@ -167,6 +195,10 @@ impl GatewayRuntimeSettingsStore {
             .store(settings.max_task_queue_len, Ordering::Release);
         self.request_file_size_limit
             .store(settings.request_file_size_limit, Ordering::Release);
+        self.taskmanager_task_lifetime_sec
+            .store(settings.taskmanager_task_lifetime_sec, Ordering::Release);
+        self.taskmanager_result_lifetime_sec
+            .store(settings.taskmanager_result_lifetime_sec, Ordering::Release);
         self.guest_generation_limit
             .store(settings.guest_generation_limit, Ordering::Release);
         self.guest_window_ms
@@ -203,6 +235,8 @@ impl GatewayRuntimeSettingsStore {
                 rate_limit_whitelist,
                 max_task_queue_len,
                 request_file_size_limit,
+                taskmanager_task_lifetime_sec,
+                taskmanager_result_lifetime_sec,
                 guest_generation_limit,
                 guest_window_ms,
                 registered_generation_limit,
@@ -224,6 +258,8 @@ impl GatewayRuntimeSettingsStore {
                     add_task_unauthorized_per_ip_daily_rate_limit,
                     max_task_queue_len,
                     request_file_size_limit,
+                    taskmanager_task_lifetime_sec,
+                    taskmanager_result_lifetime_sec,
                     guest_generation_limit,
                     guest_window_ms,
                     registered_generation_limit,
@@ -253,6 +289,8 @@ impl GatewayRuntimeSettingsStore {
                         add_task_unauthorized_per_ip_daily_rate_limit,
                         max_task_queue_len,
                         request_file_size_limit,
+                        taskmanager_task_lifetime_sec,
+                        taskmanager_result_lifetime_sec,
                         guest_generation_limit,
                         guest_window_ms,
                         registered_generation_limit,
@@ -314,6 +352,15 @@ impl GatewayRuntimeSettingsStore {
         self.cached_gateway_settings().request_file_size_limit
     }
 
+    pub fn taskmanager_task_lifetime_sec(&self) -> u64 {
+        self.cached_gateway_settings().taskmanager_task_lifetime_sec
+    }
+
+    pub fn taskmanager_result_lifetime_sec(&self) -> u64 {
+        self.cached_gateway_settings()
+            .taskmanager_result_lifetime_sec
+    }
+
     pub fn guest_generation_limit(&self) -> u64 {
         self.cached_gateway_settings().guest_generation_limit
     }
@@ -347,6 +394,8 @@ impl GatewayRuntimeSettingsStore {
                 .add_task_unauthorized_per_ip_daily_rate_limit,
             max_task_queue_len: current.max_task_queue_len,
             request_file_size_limit: current.request_file_size_limit,
+            taskmanager_task_lifetime_sec: current.taskmanager_task_lifetime_sec,
+            taskmanager_result_lifetime_sec: current.taskmanager_result_lifetime_sec,
             guest_generation_limit: current.guest_generation_limit,
             guest_window_ms: current.guest_window_ms,
             registered_generation_limit: current.registered_generation_limit,
@@ -373,6 +422,8 @@ impl GatewayRuntimeSettingsStore {
                 .add_task_unauthorized_per_ip_daily_rate_limit,
             max_task_queue_len: current.max_task_queue_len,
             request_file_size_limit: current.request_file_size_limit,
+            taskmanager_task_lifetime_sec: current.taskmanager_task_lifetime_sec,
+            taskmanager_result_lifetime_sec: current.taskmanager_result_lifetime_sec,
             guest_generation_limit: current.guest_generation_limit,
             guest_window_ms: current.guest_window_ms,
             registered_generation_limit: current.registered_generation_limit,

--- a/src/http3/handlers/task/add_task.rs
+++ b/src/http3/handlers/task/add_task.rs
@@ -229,8 +229,7 @@ pub async fn add_task_handler(
             task_kind: billing_task_kind(task_kind).to_string(),
             model: model_name.clone(),
             expected_results: cfg.node().basic.unique_workers_per_task as i32,
-            deadline_at_ms: now_ms
-                + (cfg.node().basic.taskmanager_result_lifetime.max(1) as i64 * 1000),
+            deadline_at_ms: now_ms + (gateway_state.taskmanager_task_lifetime_sec() as i64 * 1000),
             gateway_name: cfg.node().network.name.clone(),
             client_origin: billing_client_origin.to_string(),
             request_json: billing_request_json.to_string(),

--- a/src/raft/gateway_state.rs
+++ b/src/raft/gateway_state.rs
@@ -469,6 +469,40 @@ where
             .request_file_size_limit
     }
 
+    pub fn taskmanager_task_lifetime_sec(&self) -> u64 {
+        if self.has_database_gateway_settings() {
+            return self
+                .internal
+                .gateway_settings
+                .taskmanager_task_lifetime_sec()
+                .max(1);
+        }
+        self.internal
+            .config
+            .snapshot()
+            .node()
+            .basic
+            .taskmanager_task_lifetime
+            .max(1)
+    }
+
+    pub fn taskmanager_result_lifetime_sec(&self) -> u64 {
+        if self.has_database_gateway_settings() {
+            return self
+                .internal
+                .gateway_settings
+                .taskmanager_result_lifetime_sec()
+                .max(1);
+        }
+        self.internal
+            .config
+            .snapshot()
+            .node()
+            .basic
+            .taskmanager_result_lifetime
+            .max(1)
+    }
+
     pub fn guest_generation_limit(&self) -> u64 {
         self.internal.gateway_settings.guest_generation_limit()
     }

--- a/src/raft/mod.rs
+++ b/src/raft/mod.rs
@@ -941,10 +941,6 @@ pub async fn start_gateway(
         Arc::clone(&api_key_validator),
         gateway_shutdown.clone(),
     ));
-    let gateway_settings_updater = tokio::spawn(GatewayRuntimeSettingsStore::run(
-        api_key_validator.gateway_settings(),
-        gateway_shutdown.clone(),
-    ));
     let metrics = Metrics::new(0.05).map_err(|e| anyhow::anyhow!(e))?;
 
     let rate_limit_queue = RateLimitMutationBuffer::default();
@@ -952,12 +948,19 @@ pub async fn start_gateway(
         initial_capacity: cfg.basic.taskmanager_initial_capacity,
         expected_results: cfg.basic.unique_workers_per_task,
         cleanup_interval: Duration::from_secs(cfg.basic.taskmanager_cleanup_interval),
+        task_lifetime: Duration::from_secs(cfg.basic.taskmanager_task_lifetime),
         result_lifetime: Duration::from_secs(cfg.basic.taskmanager_result_lifetime),
         rate_limit_mutation_queue: rate_limit_queue.clone(),
         metrics: metrics.clone(),
         worker_event_recorder: Some(event_recorder.clone()),
     })
     .await;
+
+    let gateway_settings_updater = tokio::spawn(GatewayRuntimeSettingsStore::run(
+        api_key_validator.gateway_settings(),
+        Some(task_manager.clone()),
+        gateway_shutdown.clone(),
+    ));
 
     let gateway_state = GatewayState::new(GatewayStateInit {
         state: state_machine_store,

--- a/src/raft/rate_limit/engine.rs
+++ b/src/raft/rate_limit/engine.rs
@@ -445,10 +445,11 @@ mod tests {
         );
         let _ = raft.initialize(members).await;
 
-        let task_manager = TaskManager::new(
+        let task_manager = TaskManager::new_with_task_lifetime(
             config.basic.taskmanager_initial_capacity,
             config.basic.unique_workers_per_task,
             Duration::from_secs(config.basic.taskmanager_cleanup_interval),
+            Duration::from_secs(config.basic.taskmanager_task_lifetime),
             Duration::from_secs(config.basic.taskmanager_result_lifetime),
             Metrics::new(0.05).expect("metrics"),
             None,

--- a/src/raft/tests/cross_gateway_add_task.rs
+++ b/src/raft/tests/cross_gateway_add_task.rs
@@ -302,6 +302,7 @@ async fn build_gateway_node(
         initial_capacity: config.basic.taskmanager_initial_capacity,
         expected_results: config.basic.unique_workers_per_task,
         cleanup_interval: Duration::from_secs(config.basic.taskmanager_cleanup_interval),
+        task_lifetime: Duration::from_secs(config.basic.taskmanager_task_lifetime),
         result_lifetime: Duration::from_secs(config.basic.taskmanager_result_lifetime),
         rate_limit_mutation_queue: rate_limit_queue.clone(),
         metrics: metrics.clone(),

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -9,6 +9,7 @@ use std::cmp::Reverse;
 use std::collections::BinaryHeap;
 use std::fmt;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 use tokio::task;
 use tokio_util::sync::CancellationToken;
@@ -33,6 +34,7 @@ pub(crate) fn rate_limit_completion_request_id(task_id: Uuid) -> u128 {
 struct TaskManagerInnerInit {
     initial_capacity: usize,
     expected_results: usize,
+    task_lifetime: Duration,
     result_lifetime: Duration,
     expiration_queue: scc::Queue<ExpirationEvent>,
     rate_limit_mutation_queue: RateLimitMutationBuffer,
@@ -44,6 +46,7 @@ pub struct TaskManagerInit {
     pub initial_capacity: usize,
     pub expected_results: usize,
     pub cleanup_interval: Duration,
+    pub task_lifetime: Duration,
     pub result_lifetime: Duration,
     pub rate_limit_mutation_queue: RateLimitMutationBuffer,
     pub metrics: Metrics,
@@ -53,7 +56,8 @@ pub struct TaskManagerInit {
 struct TaskManagerInner {
     tasks: HashMap<Uuid, TaskState, RandomState>,
     expected_results: usize,
-    result_lifetime: Duration,
+    task_lifetime_ms: AtomicU64,
+    result_lifetime_ms: AtomicU64,
     metrics: Metrics,
     worker_event_recorder: Option<EventRecorder>,
     expiration_queue: scc::Queue<ExpirationEvent>,
@@ -104,10 +108,19 @@ struct ExpirationEvent {
 }
 
 impl TaskManagerInner {
+    fn duration_to_millis(duration: Duration) -> u64 {
+        duration.as_millis().clamp(1, u64::MAX as u128) as u64
+    }
+
+    fn duration_from_millis(value: u64) -> Duration {
+        Duration::from_millis(value.max(1))
+    }
+
     fn new(init: TaskManagerInnerInit) -> Self {
         let TaskManagerInnerInit {
             initial_capacity,
             expected_results,
+            task_lifetime,
             result_lifetime,
             expiration_queue,
             rate_limit_mutation_queue,
@@ -116,7 +129,8 @@ impl TaskManagerInner {
         } = init;
         Self {
             expected_results,
-            result_lifetime,
+            task_lifetime_ms: AtomicU64::new(Self::duration_to_millis(task_lifetime)),
+            result_lifetime_ms: AtomicU64::new(Self::duration_to_millis(result_lifetime)),
             metrics,
             worker_event_recorder,
             tasks: HashMap::with_capacity_and_hasher(initial_capacity, RandomState::default()),
@@ -140,13 +154,28 @@ impl TaskManagerInner {
             kind: ExpirationKind::Results,
         });
     }
+
+    fn task_lifetime(&self) -> Duration {
+        Self::duration_from_millis(self.task_lifetime_ms.load(Ordering::Acquire))
+    }
+
+    fn result_lifetime(&self) -> Duration {
+        Self::duration_from_millis(self.result_lifetime_ms.load(Ordering::Acquire))
+    }
+
+    fn set_lifetimes(&self, task_lifetime: Duration, result_lifetime: Duration) {
+        self.task_lifetime_ms
+            .store(Self::duration_to_millis(task_lifetime), Ordering::Release);
+        self.result_lifetime_ms
+            .store(Self::duration_to_millis(result_lifetime), Ordering::Release);
+    }
 }
 
 impl TaskState {
-    fn new(task: &crate::api::Task, now: Instant, result_lifetime: Duration) -> Self {
+    fn new(task: &crate::api::Task, now: Instant, task_lifetime: Duration) -> Self {
         Self {
             execution_start: Some(now),
-            task_expires_at: Some(now + result_lifetime),
+            task_expires_at: Some(now + task_lifetime),
             last_result_instant: None,
             results_expires_at: None,
             task_kind: task_kind_from_task(task),
@@ -317,10 +346,32 @@ impl TaskManager {
         metrics: Metrics,
         worker_event_recorder: Option<EventRecorder>,
     ) -> Self {
+        Self::new_with_task_lifetime(
+            initial_capacity,
+            expected_results,
+            cleanup_interval,
+            result_lifetime,
+            result_lifetime,
+            metrics,
+            worker_event_recorder,
+        )
+        .await
+    }
+
+    pub async fn new_with_task_lifetime(
+        initial_capacity: usize,
+        expected_results: usize,
+        cleanup_interval: Duration,
+        task_lifetime: Duration,
+        result_lifetime: Duration,
+        metrics: Metrics,
+        worker_event_recorder: Option<EventRecorder>,
+    ) -> Self {
         Self::new_with_rate_limit_mutation_queue(TaskManagerInit {
             initial_capacity,
             expected_results,
             cleanup_interval,
+            task_lifetime,
             result_lifetime,
             rate_limit_mutation_queue: RateLimitMutationBuffer::default(),
             metrics,
@@ -334,6 +385,7 @@ impl TaskManager {
             initial_capacity,
             expected_results,
             cleanup_interval,
+            task_lifetime,
             result_lifetime,
             rate_limit_mutation_queue,
             metrics,
@@ -343,6 +395,7 @@ impl TaskManager {
         let inner = Arc::new(TaskManagerInner::new(TaskManagerInnerInit {
             initial_capacity,
             expected_results,
+            task_lifetime,
             result_lifetime,
             expiration_queue: scc::Queue::default(),
             rate_limit_mutation_queue,
@@ -359,6 +412,10 @@ impl TaskManager {
             cancel_token,
             _cleanup_task: Arc::new(handle),
         }
+    }
+
+    pub fn set_lifetimes(&self, task_lifetime: Duration, result_lifetime: Duration) {
+        self.inner.set_lifetimes(task_lifetime, result_lifetime);
     }
 
     fn spawn_cleanup(
@@ -472,7 +529,7 @@ impl TaskManager {
                                                         .is_none_or(|expires_at| expires_at <= now)
                                                     {
                                                         let terminal_expires_at =
-                                                            now + inner.result_lifetime;
+                                                            now + inner.result_lifetime();
                                                         state.results_expires_at =
                                                             Some(terminal_expires_at);
                                                         schedule_results_expiration =
@@ -592,7 +649,7 @@ impl TaskManager {
                     state,
                     result,
                     self.inner.expected_results,
-                    self.inner.result_lifetime,
+                    self.inner.result_lifetime(),
                 );
                 (outcome, results_expires_at, reservation)
             }
@@ -663,7 +720,7 @@ impl TaskManager {
                         state,
                         result,
                         self.inner.expected_results,
-                        self.inner.result_lifetime,
+                        self.inner.result_lifetime(),
                     );
                     (outcome, results_expires_at, reservation)
                 }
@@ -754,19 +811,19 @@ impl TaskManager {
                 state.image = task.image.clone();
                 state.model = task.model.clone();
                 state.execution_start = Some(now);
-                state.task_expires_at = Some(now + self.inner.result_lifetime);
+                state.task_expires_at = Some(now + self.inner.task_lifetime());
                 state.seed = Some(task.seed);
                 state.finished_results_count = 0;
                 state.rate_limit_reservation = rate_limit_reservation;
             }
             Entry::Vacant(entry) => {
-                let mut state = TaskState::new(task, now, self.inner.result_lifetime);
+                let mut state = TaskState::new(task, now, self.inner.task_lifetime());
                 state.rate_limit_reservation = rate_limit_reservation;
                 entry.insert_entry(state);
             }
         }
         self.inner
-            .schedule_task_expiration(task.id, now + self.inner.result_lifetime);
+            .schedule_task_expiration(task.id, now + self.inner.task_lifetime());
     }
 
     fn take_terminal_completion_reservation(

--- a/src/task/tests.rs
+++ b/src/task/tests.rs
@@ -104,6 +104,55 @@ async fn assigned_task_without_results_is_in_progress() {
 }
 
 #[tokio::test]
+async fn updated_lifetimes_apply_to_new_tasks_without_shortening_existing_tasks() {
+    let task_manager = TaskManager::new_with_task_lifetime(
+        4,
+        1,
+        Duration::from_millis(20),
+        Duration::from_millis(400),
+        Duration::from_millis(400),
+        Metrics::new(0.05).unwrap(),
+        None,
+    )
+    .await;
+    let existing_task_id = Uuid::new_v4();
+    let new_task_id = Uuid::new_v4();
+    let existing_worker = Hotkey::from_bytes(&[70u8; 32]);
+    let new_worker = Hotkey::from_bytes(&[71u8; 32]);
+
+    task_manager.add_task(sample_task(existing_task_id)).await;
+    task_manager
+        .record_assignment(
+            existing_task_id,
+            existing_worker.clone(),
+            existing_worker.to_string().into(),
+        )
+        .await;
+    task_manager.set_lifetimes(Duration::from_millis(80), Duration::from_millis(500));
+    task_manager.add_task(sample_task(new_task_id)).await;
+    task_manager
+        .record_assignment(
+            new_task_id,
+            new_worker.clone(),
+            new_worker.to_string().into(),
+        )
+        .await;
+
+    tokio::time::sleep(Duration::from_millis(180)).await;
+
+    assert_eq!(
+        task_manager.get_status(new_task_id).await,
+        TaskStatus::Failure {
+            reason: Arc::<str>::from("Task timed out"),
+        }
+    );
+    assert_eq!(
+        task_manager.get_status(existing_task_id).await,
+        TaskStatus::InProgress
+    );
+}
+
+#[tokio::test]
 async fn single_success_stays_partial_until_expected_results_are_exhausted() {
     let task_manager = TaskManager::new(
         4,
@@ -317,7 +366,7 @@ async fn stage_result_rejects_double_stage_for_same_worker() {
 #[tokio::test]
 async fn staged_result_defers_timeout_until_commit() {
     const CLEANUP_INTERVAL: Duration = Duration::from_millis(40);
-    const RESULT_LIFETIME: Duration = Duration::from_millis(120);
+    const TASK_AND_RESULT_LIFETIME: Duration = Duration::from_millis(120);
 
     let metrics = Metrics::new(0.05).unwrap();
     let mutation_queue = RateLimitMutationBuffer::default();
@@ -326,7 +375,8 @@ async fn staged_result_defers_timeout_until_commit() {
         initial_capacity: 4,
         expected_results: 1,
         cleanup_interval: CLEANUP_INTERVAL,
-        result_lifetime: RESULT_LIFETIME,
+        task_lifetime: TASK_AND_RESULT_LIFETIME,
+        result_lifetime: TASK_AND_RESULT_LIFETIME,
         rate_limit_mutation_queue: mutation_queue.clone(),
         metrics,
         worker_event_recorder: None,
@@ -363,7 +413,7 @@ async fn staged_result_defers_timeout_until_commit() {
         .unwrap();
 
     tokio::time::sleep(Duration::from_millis(
-        RESULT_LIFETIME.as_millis() as u64 + 200,
+        TASK_AND_RESULT_LIFETIME.as_millis() as u64 + 200,
     ))
     .await;
 
@@ -1095,6 +1145,7 @@ async fn emits_refund_when_task_completes_with_only_failures() {
         initial_capacity: 4,
         expected_results: 2,
         cleanup_interval: CLEANUP_INTERVAL,
+        task_lifetime: RESULT_LIFETIME,
         result_lifetime: RESULT_LIFETIME,
         rate_limit_mutation_queue: mutation_queue.clone(),
         metrics,
@@ -1186,6 +1237,7 @@ async fn waits_for_expected_results_before_emitting_refund() {
         initial_capacity: 4,
         expected_results: 2,
         cleanup_interval: CLEANUP_INTERVAL,
+        task_lifetime: RESULT_LIFETIME,
         result_lifetime: RESULT_LIFETIME,
         rate_limit_mutation_queue: mutation_queue.clone(),
         metrics,
@@ -1284,6 +1336,7 @@ async fn does_not_emit_refund_when_timeout_occurs_after_partial_success() {
         initial_capacity: 4,
         expected_results: 2,
         cleanup_interval: CLEANUP_INTERVAL,
+        task_lifetime: RESULT_LIFETIME,
         result_lifetime: RESULT_LIFETIME,
         rate_limit_mutation_queue: mutation_queue.clone(),
         metrics,
@@ -1401,6 +1454,7 @@ async fn refund_rolls_back_local_pending_capacity() {
         initial_capacity: 2,
         expected_results: 1,
         cleanup_interval: CLEANUP_INTERVAL,
+        task_lifetime: RESULT_LIFETIME,
         result_lifetime: RESULT_LIFETIME,
         rate_limit_mutation_queue: mutation_queue.clone(),
         metrics,

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -191,6 +191,7 @@ pub async fn build_shared_harness_core(
         initial_capacity: config.basic.taskmanager_initial_capacity,
         expected_results: config.basic.unique_workers_per_task,
         cleanup_interval: Duration::from_secs(config.basic.taskmanager_cleanup_interval),
+        task_lifetime: Duration::from_secs(config.basic.taskmanager_task_lifetime),
         result_lifetime: Duration::from_secs(config.basic.taskmanager_result_lifetime),
         rate_limit_mutation_queue: rate_limit_mutation_queue.clone(),
         metrics: metrics.clone(),

--- a/tests/client_http_api/generic_rate_limits.rs
+++ b/tests/client_http_api/generic_rate_limits.rs
@@ -251,7 +251,7 @@ async fn generic_key_concurrent_limit_is_shared_across_source_ips_end_to_end() {
 async fn generic_key_concurrent_limit_recovers_after_restart_timeout_end_to_end() {
     let start = GatewayRuntimeHarness::start(GatewayHarnessOptions {
         taskmanager_cleanup_interval_secs: Some(1),
-        taskmanager_result_lifetime_secs: Some(2),
+        taskmanager_task_lifetime_secs: Some(2),
         generic_key_concurrent_limit: Some(1),
         ..GatewayHarnessOptions::default()
     })

--- a/tests/client_http_api/support.rs
+++ b/tests/client_http_api/support.rs
@@ -353,6 +353,8 @@ pub(crate) async fn set_gateway_runtime_settings(
             rate_limit_whitelist: rate_limit_whitelist.to_vec(),
             max_task_queue_len,
             request_file_size_limit,
+            taskmanager_task_lifetime_sec: h.core.config.basic.taskmanager_task_lifetime as i32,
+            taskmanager_result_lifetime_sec: h.core.config.basic.taskmanager_result_lifetime as i32,
             guest_generation_limit: 1,
             guest_window_ms: 86_400_000,
             registered_generation_limit: 0,

--- a/tests/common/real_harness.rs
+++ b/tests/common/real_harness.rs
@@ -192,6 +192,7 @@ pub(crate) struct GatewayHarnessOptions {
     pub(crate) include_gateway_info: bool,
     pub(crate) worker_whitelist: Option<HashSet<Hotkey>>,
     pub(crate) taskmanager_cleanup_interval_secs: Option<u64>,
+    pub(crate) taskmanager_task_lifetime_secs: Option<u64>,
     pub(crate) taskmanager_result_lifetime_secs: Option<u64>,
     pub(crate) api_keys_update_interval_secs: Option<u64>,
     pub(crate) generic_key_concurrent_limit: Option<usize>,
@@ -203,6 +204,7 @@ impl Default for GatewayHarnessOptions {
             include_gateway_info: true,
             worker_whitelist: None,
             taskmanager_cleanup_interval_secs: None,
+            taskmanager_task_lifetime_secs: None,
             taskmanager_result_lifetime_secs: None,
             api_keys_update_interval_secs: None,
             generic_key_concurrent_limit: None,
@@ -536,6 +538,9 @@ impl GatewayRuntimeHarness {
         if let Some(cleanup_secs) = options.taskmanager_cleanup_interval_secs {
             config.basic.taskmanager_cleanup_interval = cleanup_secs;
         }
+        if let Some(task_lifetime_secs) = options.taskmanager_task_lifetime_secs {
+            config.basic.taskmanager_task_lifetime = task_lifetime_secs;
+        }
         if let Some(result_lifetime_secs) = options.taskmanager_result_lifetime_secs {
             config.basic.taskmanager_result_lifetime = result_lifetime_secs;
         }
@@ -561,6 +566,8 @@ impl GatewayRuntimeHarness {
                 rate_limit_whitelist: config.http.rate_limit_whitelist.iter().cloned().collect(),
                 max_task_queue_len: config.http.max_task_queue_len as i32,
                 request_file_size_limit: config.http.request_file_size_limit as i64,
+                taskmanager_task_lifetime_sec: config.basic.taskmanager_task_lifetime as i32,
+                taskmanager_result_lifetime_sec: config.basic.taskmanager_result_lifetime as i32,
                 guest_generation_limit: 1,
                 guest_window_ms: 86_400_000,
                 registered_generation_limit: 0,
@@ -778,6 +785,8 @@ pub(crate) struct GatewayRuntimeAppSettingsUpdate {
     pub(crate) rate_limit_whitelist: Vec<String>,
     pub(crate) max_task_queue_len: i32,
     pub(crate) request_file_size_limit: i64,
+    pub(crate) taskmanager_task_lifetime_sec: i32,
+    pub(crate) taskmanager_result_lifetime_sec: i32,
     pub(crate) guest_generation_limit: i32,
     pub(crate) guest_window_ms: i64,
     pub(crate) registered_generation_limit: i32,
@@ -791,8 +800,8 @@ pub(crate) async fn update_app_settings_gateway_runtime(
     let now = current_time_ms();
     client
         .execute(
-            "UPDATE app_settings SET gateway_generic_key = $1, gateway_generic_global_daily_limit = $2, gateway_generic_per_ip_daily_limit = $3, add_task_unauthorized_per_ip_daily_rate_limit = $4, rate_limit_whitelist = $5, max_task_queue_len = $6, request_file_size_limit = $7, guest_generation_limit = $8, guest_window_ms = $9, registered_generation_limit = $10, registered_window_ms = $11, updated_at = $12 WHERE id = 1",
-            &[&update.generic_key, &update.global_limit, &update.per_ip_limit, &update.unauthorized_per_ip_limit, &update.rate_limit_whitelist, &update.max_task_queue_len, &update.request_file_size_limit, &update.guest_generation_limit, &update.guest_window_ms, &update.registered_generation_limit, &update.registered_window_ms, &now],
+            "UPDATE app_settings SET gateway_generic_key = $1, gateway_generic_global_daily_limit = $2, gateway_generic_per_ip_daily_limit = $3, add_task_unauthorized_per_ip_daily_rate_limit = $4, rate_limit_whitelist = $5, max_task_queue_len = $6, request_file_size_limit = $7, taskmanager_task_lifetime_sec = $8, taskmanager_result_lifetime_sec = $9, guest_generation_limit = $10, guest_window_ms = $11, registered_generation_limit = $12, registered_window_ms = $13, updated_at = $14 WHERE id = 1",
+            &[&update.generic_key, &update.global_limit, &update.per_ip_limit, &update.unauthorized_per_ip_limit, &update.rate_limit_whitelist, &update.max_task_queue_len, &update.request_file_size_limit, &update.taskmanager_task_lifetime_sec, &update.taskmanager_result_lifetime_sec, &update.guest_generation_limit, &update.guest_window_ms, &update.registered_generation_limit, &update.registered_window_ms, &now],
         )
         .await
         .context("update gateway runtime app settings")?;

--- a/tests/event_tracker/support.rs
+++ b/tests/event_tracker/support.rs
@@ -333,6 +333,10 @@ pub(crate) async fn set_request_file_size_limit(
                 .collect(),
             max_task_queue_len: harness.core.config.http.max_task_queue_len as i32,
             request_file_size_limit,
+            taskmanager_task_lifetime_sec: harness.core.config.basic.taskmanager_task_lifetime
+                as i32,
+            taskmanager_result_lifetime_sec: harness.core.config.basic.taskmanager_result_lifetime
+                as i32,
             guest_generation_limit: 1,
             guest_window_ms: 86_400_000,
             registered_generation_limit: 0,

--- a/tests/event_tracker/worker.rs
+++ b/tests/event_tracker/worker.rs
@@ -238,7 +238,7 @@ async fn records_worker_timeout_event() {
         None,
         GatewayHarnessOptions {
             taskmanager_cleanup_interval_secs: Some(1),
-            taskmanager_result_lifetime_secs: Some(1),
+            taskmanager_task_lifetime_secs: Some(1),
             ..GatewayHarnessOptions::default()
         },
     )


### PR DESCRIPTION
1. Split gateway task timeout from result retention with new taskmanager_task_lifetime.
2. Set workers default task deadline to 10 minutes and in-memory result retention to 5 minutes.
3. Use task lifetime, not result lifetime, for DB generation task deadlines.